### PR TITLE
feat(services): enumerate installed Windows services and sanitize JSO…

### DIFF
--- a/WindowsEnum/Windows-Info-Gathering.vcxproj
+++ b/WindowsEnum/Windows-Info-Gathering.vcxproj
@@ -199,6 +199,7 @@
     <ClCompile Include="src\InstalledUpdates.cpp" />
     <ClCompile Include="src\Service\ServiceMain.cpp" />
     <ClCompile Include="src\Service\ServiceTamperProtection.cpp" />
+    <ClCompile Include="src\WindowsServices.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\OsVersionInfo.h" />
@@ -220,6 +221,7 @@
     <ClInclude Include="src\Service\ServiceInstaller.h" />
     <ClInclude Include="src\Service\ServiceMain.h" />
     <ClInclude Include="src\Service\ServiceTamperProtection.h" />
+    <ClInclude Include="src\WindowsServices.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include=".github\copilot-instructions.md" />

--- a/WindowsEnum/src/Utils/Utils.cpp
+++ b/WindowsEnum/src/Utils/Utils.cpp
@@ -93,11 +93,49 @@ void LogWideStringAsUtf8(const std::string& prefix, const std::wstring& value)
 // UTF-8 JSON ESCAPE
 std::string JsonEscape(const std::wstring& input)
 {
-    int sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, input.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    // Sanitize input by removing invisible Unicode formatting characters
+    // (e.g., LRM/RLM, LRE/RLE, PDF, isolate controls) which may be present
+    // in registry values or service descriptions and can corrupt JSON display.
+    auto SanitizeForJson = [](const std::wstring& s) {
+        std::wstring out;
+        out.reserve(s.size());
+        for (wchar_t ch : s)
+        {
+            // Allow common whitespace characters
+            if (ch == L'\r' || ch == L'\n' || ch == L'\t')
+            {
+                out.push_back(ch);
+                continue;
+            }
+
+            // Skip C0 control characters
+            if (ch < 0x20)
+                continue;
+
+            // Skip known Unicode format/isolate and bidi control characters
+            // U+061C (ALM), U+200E (LRM), U+200F (RLM)
+            // U+202A..U+202E (LRE, RLE, PDF, LRO, RLO)
+            // U+2066..U+2069 (isolate controls)
+            const wchar_t chv = ch;
+            if (chv == 0x061C || chv == 0x200E || chv == 0x200F ||
+                (chv >= 0x202A && chv <= 0x202E) ||
+                (chv >= 0x2066 && chv <= 0x2069))
+            {
+                continue;
+            }
+
+            out.push_back(ch);
+        }
+        return out;
+    };
+
+    std::wstring sanitized = SanitizeForJson(input);
+
+    int sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, sanitized.c_str(), -1, nullptr, 0, nullptr, nullptr);
     if (sizeNeeded <= 0) return "\"\"";
 
     std::string utf8(sizeNeeded - 1, '\0');
-    WideCharToMultiByte(CP_UTF8, 0, input.c_str(), -1, utf8.data(), sizeNeeded, nullptr, nullptr);
+    WideCharToMultiByte(CP_UTF8, 0, sanitized.c_str(), -1, utf8.data(), sizeNeeded, nullptr, nullptr);
 
     std::ostringstream out;
     out << "\"";
@@ -445,6 +483,9 @@ std::string GenerateJSON()
 
     svipAddresses = GetLocalIPAddresses();
 
+    // Enumerate all installed Windows services via SCM APIs
+    std::vector<WindowsServiceInfo> windowsServices = EnumerateWindowsServices();
+
     // Get ISO 8601 timestamp for collection
     auto now = std::chrono::system_clock::now();
     auto time = std::chrono::system_clock::to_time_t(now);
@@ -657,7 +698,30 @@ std::string GenerateJSON()
     }
     out << "    ]\n";
 
-    out << "  }\n";
+    out << "  },\n";
+
+    // Windows Services — array of all installed Win32 services
+    out << "  \"windowsServices\": [\n";
+    for (size_t i = 0; i < windowsServices.size(); ++i)
+    {
+        const auto& svc = windowsServices[i];
+        out << "    {\n";
+        out << "      \"serviceName\": " << JsonEscape(svc.serviceName) << ",\n";
+        out << "      \"displayName\": " << JsonEscape(svc.displayName) << ",\n";
+        out << "      \"description\": " << JsonEscape(svc.description) << ",\n";
+        out << "      \"binaryPathName\": " << JsonEscape(svc.binaryPathName) << ",\n";
+        out << "      \"serviceStartName\": " << JsonEscape(svc.serviceStartName) << ",\n";
+        out << "      \"startType\": " << JsonEscape(svc.startType) << ",\n";
+        out << "      \"currentState\": " << JsonEscape(svc.currentState) << ",\n";
+        out << "      \"serviceType\": " << JsonEscape(svc.serviceType) << ",\n";
+        out << "      \"processId\": " << svc.processId << ",\n";
+        out << "      \"isRunning\": " << (svc.isRunning ? "true" : "false") << "\n";
+        out << "    }";
+        if (i + 1 < windowsServices.size()) out << ",";
+        out << "\n";
+    }
+    out << "  ]\n";
+
     out << "}\n";
 
     return out.str();

--- a/WindowsEnum/src/WindowsEnum.h
+++ b/WindowsEnum/src/WindowsEnum.h
@@ -12,3 +12,4 @@
 #include "PrivMgmt.h"
 #include "InstalledUpdates.h"
 #include "OsVersionInfo.h"
+#include "WindowsServices.h"

--- a/WindowsEnum/src/WindowsServices.cpp
+++ b/WindowsEnum/src/WindowsServices.cpp
@@ -1,0 +1,332 @@
+#include "WindowsServices.h"
+#include "Utils/Utils.h"
+#include <memory>
+
+#pragma comment(lib, "advapi32.lib")
+
+// RAII wrapper for SC_HANDLE to prevent handle leaks.
+// SC_HANDLE is closed via CloseServiceHandle, not CloseHandle.
+class ScHandleGuard
+{
+public:
+    explicit ScHandleGuard(SC_HANDLE handle = nullptr) noexcept : m_handle(handle) {}
+    ~ScHandleGuard() noexcept
+    {
+        if (m_handle != nullptr)
+        {
+            CloseServiceHandle(m_handle);
+        }
+    }
+
+    // Non-copyable
+    ScHandleGuard(const ScHandleGuard&) = delete;
+    ScHandleGuard& operator=(const ScHandleGuard&) = delete;
+
+    // Movable
+    ScHandleGuard(ScHandleGuard&& other) noexcept : m_handle(other.m_handle)
+    {
+        other.m_handle = nullptr;
+    }
+
+    ScHandleGuard& operator=(ScHandleGuard&& other) noexcept
+    {
+        if (this != &other)
+        {
+            if (m_handle != nullptr)
+            {
+                CloseServiceHandle(m_handle);
+            }
+            m_handle = other.m_handle;
+            other.m_handle = nullptr;
+        }
+        return *this;
+    }
+
+    SC_HANDLE Get() const noexcept { return m_handle; }
+    explicit operator bool() const noexcept { return m_handle != nullptr; }
+
+private:
+    SC_HANDLE m_handle;
+};
+
+// Convert SERVICE_STATUS_PROCESS.dwCurrentState to a human-readable string.
+static std::wstring ServiceStateToString(DWORD state) noexcept
+{
+    switch (state)
+    {
+    case SERVICE_RUNNING:          return L"Running";
+    case SERVICE_STOPPED:          return L"Stopped";
+    case SERVICE_START_PENDING:    return L"StartPending";
+    case SERVICE_STOP_PENDING:     return L"StopPending";
+    case SERVICE_CONTINUE_PENDING: return L"ContinuePending";
+    case SERVICE_PAUSE_PENDING:    return L"PausePending";
+    case SERVICE_PAUSED:           return L"Paused";
+    default:                       return L"Unknown";
+    }
+}
+
+// Convert QUERY_SERVICE_CONFIG.dwStartType to a human-readable string.
+// Checks for delayed auto-start via QueryServiceConfig2W.
+static std::wstring StartTypeToString(DWORD startType, bool isDelayedAutoStart) noexcept
+{
+    switch (startType)
+    {
+    case SERVICE_AUTO_START:
+        return isDelayedAutoStart ? L"DelayedAuto" : L"Auto";
+    case SERVICE_DEMAND_START:     return L"Manual";
+    case SERVICE_DISABLED:         return L"Disabled";
+    case SERVICE_BOOT_START:       return L"Boot";
+    case SERVICE_SYSTEM_START:     return L"System";
+    default:                       return L"Unknown";
+    }
+}
+
+// Convert QUERY_SERVICE_CONFIG.dwServiceType to a human-readable string.
+static std::wstring ServiceTypeToString(DWORD serviceType) noexcept
+{
+    // Check combined types first (most common for Win32 services)
+    if (serviceType & SERVICE_WIN32_OWN_PROCESS)
+        return L"Win32OwnProcess";
+    if (serviceType & SERVICE_WIN32_SHARE_PROCESS)
+        return L"Win32ShareProcess";
+    if (serviceType & SERVICE_KERNEL_DRIVER)
+        return L"KernelDriver";
+    if (serviceType & SERVICE_FILE_SYSTEM_DRIVER)
+        return L"FileSystemDriver";
+
+    return L"Unknown";
+}
+
+// Query the service description via QueryServiceConfig2W.
+// Returns empty string on failure (non-fatal).
+static std::wstring QueryServiceDescription(SC_HANDLE hService)
+{
+    DWORD bytesNeeded = 0;
+
+    // First call: determine buffer size
+    QueryServiceConfig2W(hService, SERVICE_CONFIG_DESCRIPTION, nullptr, 0, &bytesNeeded);
+
+    if (bytesNeeded == 0)
+    {
+        return {};
+    }
+
+    std::vector<BYTE> buffer(bytesNeeded);
+    if (!QueryServiceConfig2W(hService, SERVICE_CONFIG_DESCRIPTION,
+                              buffer.data(), bytesNeeded, &bytesNeeded))
+    {
+        return {};
+    }
+
+    const auto* pDesc = reinterpret_cast<const SERVICE_DESCRIPTIONW*>(buffer.data());
+    if (pDesc->lpDescription != nullptr)
+    {
+        return std::wstring(pDesc->lpDescription);
+    }
+
+    return {};
+}
+
+// Query whether the service has delayed auto-start enabled.
+// Returns false on failure or if not applicable (non-fatal).
+static bool QueryDelayedAutoStart(SC_HANDLE hService)
+{
+    DWORD bytesNeeded = 0;
+
+    QueryServiceConfig2W(hService, SERVICE_CONFIG_DELAYED_AUTO_START_INFO, nullptr, 0, &bytesNeeded);
+
+    if (bytesNeeded == 0)
+    {
+        return false;
+    }
+
+    std::vector<BYTE> buffer(bytesNeeded);
+    if (!QueryServiceConfig2W(hService, SERVICE_CONFIG_DELAYED_AUTO_START_INFO,
+                              buffer.data(), bytesNeeded, &bytesNeeded))
+    {
+        return false;
+    }
+
+    const auto* pDelayed = reinterpret_cast<const SERVICE_DELAYED_AUTO_START_INFO*>(buffer.data());
+    return pDelayed->fDelayedAutostart != FALSE;
+}
+
+// Query service configuration (binary path, start type, account) via QueryServiceConfigW.
+// Populates the corresponding fields in serviceInfo.
+static void QueryServiceConfiguration(SC_HANDLE hService, WindowsServiceInfo& serviceInfo)
+{
+    DWORD bytesNeeded = 0;
+
+    // First call: determine buffer size
+    QueryServiceConfigW(hService, nullptr, 0, &bytesNeeded);
+    DWORD lastError = GetLastError();
+
+    if (lastError != ERROR_INSUFFICIENT_BUFFER || bytesNeeded == 0)
+    {
+        LogError("[-] QueryServiceConfigW sizing call failed for service: " +
+                 WideToUtf8(serviceInfo.serviceName) + ", error: " + std::to_string(lastError));
+        return;
+    }
+
+    std::vector<BYTE> buffer(bytesNeeded);
+    auto* pConfig = reinterpret_cast<LPQUERY_SERVICE_CONFIGW>(buffer.data());
+
+    if (!QueryServiceConfigW(hService, pConfig, bytesNeeded, &bytesNeeded))
+    {
+        LogError("[-] QueryServiceConfigW failed for service: " +
+                 WideToUtf8(serviceInfo.serviceName) + ", error: " + std::to_string(GetLastError()));
+        return;
+    }
+
+    // Extract configuration fields (validate pointers — SCM returns embedded pointers)
+    if (pConfig->lpBinaryPathName != nullptr)
+    {
+        serviceInfo.binaryPathName = pConfig->lpBinaryPathName;
+    }
+
+    if (pConfig->lpServiceStartName != nullptr)
+    {
+        serviceInfo.serviceStartName = pConfig->lpServiceStartName;
+    }
+
+    // Determine if delayed auto-start is enabled (only relevant for auto-start services)
+    bool isDelayedAutoStart = false;
+    if (pConfig->dwStartType == SERVICE_AUTO_START)
+    {
+        isDelayedAutoStart = QueryDelayedAutoStart(hService);
+    }
+
+    serviceInfo.startType = StartTypeToString(pConfig->dwStartType, isDelayedAutoStart);
+    serviceInfo.serviceType = ServiceTypeToString(pConfig->dwServiceType);
+
+    // Query description (optional, non-fatal if missing)
+    serviceInfo.description = QueryServiceDescription(hService);
+}
+
+std::vector<WindowsServiceInfo> EnumerateWindowsServices()
+{
+    std::vector<WindowsServiceInfo> services;
+
+    // Open the SCM with enumerate access (least privilege)
+    ScHandleGuard hSCManager(OpenSCManagerW(nullptr, nullptr, SC_MANAGER_ENUMERATE_SERVICE));
+    if (!hSCManager)
+    {
+        LogError("[-] OpenSCManagerW failed, error: " + std::to_string(GetLastError()) +
+                 " — " + GetWindowsErrorMessage(static_cast<LONG>(GetLastError())));
+        return services;
+    }
+
+    // First call: determine required buffer size for all Win32 services
+    DWORD bytesNeeded = 0;
+    DWORD serviceCount = 0;
+    DWORD resumeHandle = 0;
+
+    EnumServicesStatusExW(
+        hSCManager.Get(),
+        SC_ENUM_PROCESS_INFO,
+        SERVICE_WIN32,          // Win32OwnProcess + Win32ShareProcess
+        SERVICE_STATE_ALL,      // Both running and stopped services
+        nullptr,
+        0,
+        &bytesNeeded,
+        &serviceCount,
+        &resumeHandle,
+        nullptr                 // All groups
+    );
+
+    DWORD lastError = GetLastError();
+    if (lastError != ERROR_MORE_DATA || bytesNeeded == 0)
+    {
+        LogError("[-] EnumServicesStatusExW sizing call failed, error: " +
+                 std::to_string(lastError) + " — " + GetWindowsErrorMessage(static_cast<LONG>(lastError)));
+        return services;
+    }
+
+    // Allocate buffer and enumerate all services
+    // Add extra margin for services that may be registered between the two calls
+    const DWORD bufferSize = bytesNeeded + 4096;
+    std::vector<BYTE> buffer(bufferSize);
+    resumeHandle = 0;
+
+    if (!EnumServicesStatusExW(
+            hSCManager.Get(),
+            SC_ENUM_PROCESS_INFO,
+            SERVICE_WIN32,
+            SERVICE_STATE_ALL,
+            buffer.data(),
+            bufferSize,
+            &bytesNeeded,
+            &serviceCount,
+            &resumeHandle,
+            nullptr))
+    {
+        lastError = GetLastError();
+
+        // ERROR_MORE_DATA means partial results — process what we have
+        if (lastError != ERROR_MORE_DATA)
+        {
+            LogError("[-] EnumServicesStatusExW failed, error: " +
+                     std::to_string(lastError) + " — " + GetWindowsErrorMessage(static_cast<LONG>(lastError)));
+            return services;
+        }
+
+        LogError("[!] EnumServicesStatusExW returned partial results (" +
+                 std::to_string(serviceCount) + " services), some services may be missing");
+    }
+
+    if (serviceCount == 0)
+    {
+        LogError("[!] EnumServicesStatusExW returned 0 services");
+        return services;
+    }
+
+    services.reserve(serviceCount);
+
+    const auto* pServiceStatus = reinterpret_cast<const ENUM_SERVICE_STATUS_PROCESSW*>(buffer.data());
+
+    for (DWORD i = 0; i < serviceCount; ++i)
+    {
+        const auto& svc = pServiceStatus[i];
+
+        WindowsServiceInfo info = {};
+
+        // Service name and display name come from the enumeration
+        if (svc.lpServiceName != nullptr)
+        {
+            info.serviceName = svc.lpServiceName;
+        }
+        if (svc.lpDisplayName != nullptr)
+        {
+            info.displayName = svc.lpDisplayName;
+        }
+
+        // Status and PID from SERVICE_STATUS_PROCESS
+        info.currentState = ServiceStateToString(svc.ServiceStatusProcess.dwCurrentState);
+        info.processId = svc.ServiceStatusProcess.dwProcessId;
+        info.isRunning = (svc.ServiceStatusProcess.dwCurrentState == SERVICE_RUNNING);
+
+        // Open individual service handle to query configuration
+        // Use SERVICE_QUERY_CONFIG — least privilege for config queries
+        ScHandleGuard hService(OpenServiceW(hSCManager.Get(), svc.lpServiceName, SERVICE_QUERY_CONFIG));
+        if (hService)
+        {
+            QueryServiceConfiguration(hService.Get(), info);
+        }
+        else
+        {
+            // Non-fatal: we still have name and status from enumeration
+            // This can happen for services with restricted ACLs
+            DWORD openError = GetLastError();
+            if (openError != ERROR_ACCESS_DENIED)
+            {
+                LogError("[!] OpenServiceW failed for: " + WideToUtf8(info.serviceName) +
+                         ", error: " + std::to_string(openError));
+            }
+        }
+
+        services.push_back(std::move(info));
+    }
+
+    LogError("[+] Enumerated " + std::to_string(services.size()) + " Windows services");
+    return services;
+}

--- a/WindowsEnum/src/WindowsServices.h
+++ b/WindowsEnum/src/WindowsServices.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <string>
+#include <vector>
+
+// Represents a single Windows service installed on the system.
+// Collected via the Service Control Manager (SCM) APIs.
+struct WindowsServiceInfo
+{
+    std::wstring serviceName;           // Internal service name (e.g., "wuauserv")
+    std::wstring displayName;           // Human-readable display name (e.g., "Windows Update")
+    std::wstring description;           // Service description text
+    std::wstring binaryPathName;        // Path to the service executable (may include arguments)
+    std::wstring serviceStartName;      // Account under which the service runs (e.g., "LocalSystem")
+    std::wstring startType;             // "Auto", "DelayedAuto", "Manual", "Disabled", "Boot", "System"
+    std::wstring currentState;          // "Running", "Stopped", "StartPending", "StopPending", etc.
+    std::wstring serviceType;           // "Win32OwnProcess", "Win32ShareProcess", "KernelDriver", etc.
+    DWORD processId = 0;                // PID of the running service process (0 if not running)
+    bool isRunning = false;             // Convenience flag: true if currentState is "Running"
+};
+
+// Enumerate all installed Win32 services and their current status.
+// Uses SCM APIs: OpenSCManagerW, EnumServicesStatusExW, QueryServiceConfigW, QueryServiceConfig2W.
+// Privilege requirement: SC_MANAGER_ENUMERATE_SERVICE and SERVICE_QUERY_CONFIG (no elevation needed).
+// Returns an empty vector on failure (errors are logged internally).
+std::vector<WindowsServiceInfo> EnumerateWindowsServices();


### PR DESCRIPTION
…N output

•	Add WindowsServices.h / WindowsServices.cpp:
•	Enumerate Win32 services using SCM APIs (OpenSCManagerW, EnumServicesStatusExW). •	Query per-service configuration (OpenServiceW + QueryServiceConfigW / QueryServiceConfig2W) for binary path, start type, account and description. •	RAII ScHandleGuard to safely manage SC_HANDLE lifetimes. •	Use least-privilege access (SC_MANAGER_ENUMERATE_SERVICE, SERVICE_QUERY_CONFIG) and robust error handling/logging. •	Map native service fields into WindowsServiceInfo struct. •	Integrate services into inventory JSON:
•	Include WindowsServices.h from WindowsEnum.h.
•	Call EnumerateWindowsServices() in GenerateJSON() and serialize a new "windowsServices" array in the JSON output. •	Fix JSON formatting issues caused by invisible Unicode characters: •	Enhance JsonEscape() to sanitize wide strings by removing bidi/isolate/formatting control characters (e.g., U+200E/U+200F, U+202A..U+202E, U+2066..U+2069, U+061C) and C0 controls (except CR/LF/tab) before UTF-8 conversion and escaping. •	Prevent hidden characters from appearing in inventory.json descriptions/fields. •	Notes:
•	Non-fatal failures to open/query services are logged but do not abort overall collection (handles services with restricted ACLs). •	Build verified locally (build successful).
This change improves inventory completeness (service list + running state) and fixes corrupted/hidden characters in JSON output.

Fixes #54