### PR TITLE
feat: add real-time process execution tracking via ETW

### DIFF
--- a/WindowsEnum/Windows-Info-Gathering.vcxproj
+++ b/WindowsEnum/Windows-Info-Gathering.vcxproj
@@ -200,6 +200,7 @@
     <ClCompile Include="src\Service\ServiceMain.cpp" />
     <ClCompile Include="src\Service\ServiceTamperProtection.cpp" />
     <ClCompile Include="src\WindowsServices.cpp" />
+    <ClCompile Include="src\ProcessTracker.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\OsVersionInfo.h" />
@@ -222,6 +223,7 @@
     <ClInclude Include="src\Service\ServiceMain.h" />
     <ClInclude Include="src\Service\ServiceTamperProtection.h" />
     <ClInclude Include="src\WindowsServices.h" />
+    <ClInclude Include="src\ProcessTracker.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include=".github\copilot-instructions.md" />

--- a/WindowsEnum/Windows-Info-Gathering.vcxproj.filters
+++ b/WindowsEnum/Windows-Info-Gathering.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -72,6 +72,12 @@
     <ClCompile Include="src\OsVersionInfo.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\WindowsServices.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\ProcessTracker.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Utils\Utils.h">
@@ -131,6 +137,12 @@
     <ClInclude Include="src\OsVersionInfo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\WindowsServices.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ProcessTracker.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="README_RUN_AS_SYSTEM.md" />
@@ -145,3 +157,4 @@
     <None Include="REBUILD_INSTRUCTIONS.md" />
   </ItemGroup>
 </Project>
+

--- a/WindowsEnum/src/Main.cpp
+++ b/WindowsEnum/src/Main.cpp
@@ -121,6 +121,9 @@ int RunConsoleMode()
     std::string jsonData = GenerateJSON();
     WriteJSONToFile(jsonData);
     
+    std::string processData = GenerateProcessJSON();
+    WriteJSONToFile(processData, L"processes.json");
+    
     LogError("[+] Console mode execution completed");
     return 0;
 }
@@ -132,16 +135,19 @@ int RunTestMode()
     LogError("[+] Performing single data collection for validation...");
     
     std::string jsonData = GenerateJSON();
+    std::string processData = GenerateProcessJSON();
     
     std::cout << "\n==========================================================\n";
     std::cout << "DATA COLLECTION TEST COMPLETED\n";
     std::cout << "==========================================================\n";
-    std::cout << "JSON Output Size: " << jsonData.size() << " bytes\n";
+    std::cout << "Inventory JSON Size: " << jsonData.size() << " bytes\n";
+    std::cout << "Process JSON Size:   " << processData.size() << " bytes\n";
     std::cout << "Output Location: Current Directory\n";
     std::cout << "\nTo install as service, run: Spectra.exe /install\n";
     std::cout << "==========================================================\n";
     
     WriteJSONToFile(jsonData);
+    WriteJSONToFile(processData, L"processes.json");
     return 0;
 }
 

--- a/WindowsEnum/src/ProcessTracker.cpp
+++ b/WindowsEnum/src/ProcessTracker.cpp
@@ -1,0 +1,1181 @@
+﻿#include "ProcessTracker.h"
+#include "Utils/Utils.h"
+#include "Service/ServiceConfig.h"
+#include <tlhelp32.h>
+#include <sddl.h>
+#include <tdh.h>
+#include <psapi.h>
+#include <winevt.h>
+#include <iomanip>
+#include <chrono>
+#include <sstream>
+#include <functional>
+
+#pragma comment(lib, "advapi32.lib")
+#pragma comment(lib, "tdh.lib")
+
+// ============================================================================
+// RAII Handle Wrappers
+// Prevent handle leaks in all code paths (exceptions, early returns).
+// Each wrapper calls the correct close function for its handle type.
+// ============================================================================
+
+// RAII wrapper for generic Windows HANDLE (CloseHandle).
+class WinHandle {
+public:
+    explicit WinHandle(HANDLE h = nullptr) noexcept : m_handle(h) {}
+    ~WinHandle() noexcept { Reset(); }
+
+    WinHandle(const WinHandle&) = delete;
+    WinHandle& operator=(const WinHandle&) = delete;
+
+    WinHandle(WinHandle&& other) noexcept : m_handle(other.m_handle) { other.m_handle = nullptr; }
+    WinHandle& operator=(WinHandle&& other) noexcept {
+        if (this != &other) { Reset(); m_handle = other.m_handle; other.m_handle = nullptr; }
+        return *this;
+    }
+
+    void Reset() noexcept {
+        if (m_handle != nullptr && m_handle != INVALID_HANDLE_VALUE) {
+            CloseHandle(m_handle);
+        }
+        m_handle = nullptr;
+    }
+
+    HANDLE Get() const noexcept { return m_handle; }
+    HANDLE Release() noexcept { HANDLE h = m_handle; m_handle = nullptr; return h; }
+    explicit operator bool() const noexcept { return m_handle != nullptr && m_handle != INVALID_HANDLE_VALUE; }
+
+private:
+    HANDLE m_handle;
+};
+
+// RAII wrapper for Toolhelp snapshot handles (INVALID_HANDLE_VALUE sentinel).
+class SnapshotHandle {
+public:
+    explicit SnapshotHandle(HANDLE h = INVALID_HANDLE_VALUE) noexcept : m_handle(h) {}
+    ~SnapshotHandle() noexcept { Reset(); }
+
+    SnapshotHandle(const SnapshotHandle&) = delete;
+    SnapshotHandle& operator=(const SnapshotHandle&) = delete;
+
+    SnapshotHandle(SnapshotHandle&& other) noexcept : m_handle(other.m_handle) { other.m_handle = INVALID_HANDLE_VALUE; }
+    SnapshotHandle& operator=(SnapshotHandle&& other) noexcept {
+        if (this != &other) { Reset(); m_handle = other.m_handle; other.m_handle = INVALID_HANDLE_VALUE; }
+        return *this;
+    }
+
+    void Reset() noexcept {
+        if (m_handle != INVALID_HANDLE_VALUE && m_handle != nullptr) {
+            CloseHandle(m_handle);
+        }
+        m_handle = INVALID_HANDLE_VALUE;
+    }
+
+    HANDLE Get() const noexcept { return m_handle; }
+    explicit operator bool() const noexcept { return m_handle != INVALID_HANDLE_VALUE && m_handle != nullptr; }
+
+private:
+    HANDLE m_handle;
+};
+
+// RAII wrapper for HMODULE (FreeLibrary).
+class LibraryHandle {
+public:
+    explicit LibraryHandle(HMODULE h = nullptr) noexcept : m_handle(h) {}
+    ~LibraryHandle() noexcept { if (m_handle) FreeLibrary(m_handle); }
+
+    LibraryHandle(const LibraryHandle&) = delete;
+    LibraryHandle& operator=(const LibraryHandle&) = delete;
+
+    HMODULE Get() const noexcept { return m_handle; }
+    explicit operator bool() const noexcept { return m_handle != nullptr; }
+
+private:
+    HMODULE m_handle;
+};
+
+// RAII wrapper for memory allocated by LocalAlloc (e.g., ConvertStringSidToSidW).
+class LocalMemGuard {
+public:
+    explicit LocalMemGuard(void* p = nullptr) noexcept : m_ptr(p) {}
+    ~LocalMemGuard() noexcept { if (m_ptr) LocalFree(m_ptr); }
+
+    LocalMemGuard(const LocalMemGuard&) = delete;
+    LocalMemGuard& operator=(const LocalMemGuard&) = delete;
+
+    void* Get() const noexcept { return m_ptr; }
+    explicit operator bool() const noexcept { return m_ptr != nullptr; }
+
+private:
+    void* m_ptr;
+};
+
+// Microsoft-Windows-Kernel-Process provider GUID
+// {22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716}
+const GUID ProcessTracker::s_kernelProcessProviderGuid =
+    { 0x22FB2CD6, 0x0E7B, 0x422B, { 0xA0, 0xC7, 0x2F, 0xAD, 0x1F, 0xD0, 0xE7, 0x16 } };
+
+// Global instance for static callback routing
+ProcessTracker* ProcessTracker::s_instance = nullptr;
+
+// Kernel-Process event IDs
+static constexpr USHORT KERNEL_PROCESS_EVENT_START = 1;   // ProcessStart
+static constexpr USHORT KERNEL_PROCESS_EVENT_STOP  = 2;   // ProcessStop
+
+// Maximum number of observed processes buffered between collections.
+// Prevents unbounded memory growth on busy servers (e.g., build farms, CI/CD).
+// At ~2 KB per RunningProcessInfo entry, 100K entries ≈ 200 MB worst-case.
+static constexpr size_t MAX_OBSERVED_PROCESSES = 100000;
+
+// Maximum length (in wchar_t) for attacker-controlled strings (imagePath, commandLine).
+// Windows command lines can reach 32,767 characters. Storing the full string in
+// 100K buffer entries + dedup map would allow an attacker to exhaust memory by
+// spawning processes with unique near-max-length command lines.
+// 8,192 characters (~16 KB) preserves full fidelity for all legitimate use
+// while capping worst-case at ~1.6 GB for the process buffer.
+static constexpr size_t MAX_PROCESS_STRING_LENGTH = 8192;
+
+// Cache TTL for services.exe PID lookup (5 minutes).
+// services.exe PID is stable but we refresh periodically for correctness.
+static constexpr ULONGLONG SERVICES_PID_CACHE_TTL_MS = 300000ULL;
+
+ProcessTracker::ProcessTracker()
+{
+    s_instance = this;
+}
+
+ProcessTracker::~ProcessTracker()
+{
+    Stop();
+    if (s_instance == this)
+    {
+        s_instance = nullptr;
+    }
+}
+
+bool ProcessTracker::Start()
+{
+    // Check if process tracking is enabled via registry config
+    if (!ServiceConfig::IsProcessTrackingEnabled())
+    {
+        LogError("[!] Process tracking is disabled via registry configuration (EnableProcessTracking=0)");
+        std::lock_guard<std::mutex> lock(m_diagMutex);
+        m_diagnostics.activeSource = ProcessTrackingSource::Disabled;
+        return false;
+    }
+
+    if (m_isRunning.load())
+    {
+        LogError("[!] ProcessTracker::Start() called but tracker is already running");
+        return true;
+    }
+
+    // Create stop event for clean shutdown
+    m_stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (m_stopEvent == nullptr)
+    {
+        LogError("[-] ProcessTracker: Failed to create stop event, error: " +
+                 std::to_string(GetLastError()));
+        return false;
+    }
+
+    LogError("[+] ProcessTracker: Attempting to start ETW session...");
+
+    // Primary: Try ETW kernel process provider
+    if (StartEtwSession())
+    {
+        m_isRunning.store(true);
+        LogError("[+] ProcessTracker: ETW session started successfully");
+        return true;
+    }
+
+    // ETW failed — log diagnostic info
+    {
+        std::lock_guard<std::mutex> lock(m_diagMutex);
+        LogError("[!] ProcessTracker: ETW session failed (error: " +
+                 std::to_string(m_diagnostics.etwSessionStartResult) +
+                 "), checking Sysmon fallback...");
+    }
+
+    // Fallback: Try Sysmon event log
+    if (StartSysmonFallback())
+    {
+        m_isRunning.store(true);
+        LogError("[+] ProcessTracker: Sysmon fallback started successfully");
+        return true;
+    }
+
+    // Both sources failed
+    LogError("[-] ProcessTracker: All process tracking sources failed. "
+             "ETW session could not be created and Sysmon is not available. "
+             "Process tracking will be inactive for this collection cycle.");
+
+    if (m_stopEvent != nullptr)
+    {
+        CloseHandle(m_stopEvent);
+        m_stopEvent = nullptr;
+    }
+
+    return false;
+}
+
+void ProcessTracker::Stop()
+{
+    if (!m_isRunning.load() && m_stopEvent == nullptr)
+    {
+        return;
+    }
+
+    LogError("[+] ProcessTracker: Stopping...");
+
+    // Signal stop to all threads
+    if (m_stopEvent != nullptr)
+    {
+        SetEvent(m_stopEvent);
+    }
+
+    StopEtwSession();
+    StopSysmonFallback();
+
+    if (m_stopEvent != nullptr)
+    {
+        CloseHandle(m_stopEvent);
+        m_stopEvent = nullptr;
+    }
+
+    m_isRunning.store(false);
+    LogError("[+] ProcessTracker: Stopped");
+}
+
+std::vector<RunningProcessInfo> ProcessTracker::CollectAndReset()
+{
+    std::lock_guard<std::mutex> lock(m_processMutex);
+    std::vector<RunningProcessInfo> result;
+    result.swap(m_observedProcesses);
+    return result;
+}
+
+ProcessTrackerDiagnostics ProcessTracker::GetDiagnostics() const
+{
+    std::lock_guard<std::mutex> lock(m_diagMutex);
+    return m_diagnostics;
+}
+
+bool ProcessTracker::IsRunning() const
+{
+    return m_isRunning.load();
+}
+
+// ============================================================================
+// ETW Session Management
+// ============================================================================
+
+bool ProcessTracker::StartEtwSession()
+{
+    // Allocate EVENT_TRACE_PROPERTIES with space for session name + log file name
+    const size_t sessionNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
+    const size_t logFileNameOffset = sessionNameOffset + (wcslen(ETW_SESSION_NAME) + 1) * sizeof(wchar_t);
+    const size_t bufferSize = logFileNameOffset + sizeof(wchar_t); // No log file name needed
+
+    std::vector<BYTE> propertiesBuffer(bufferSize, 0);
+    auto* pProperties = reinterpret_cast<EVENT_TRACE_PROPERTIES*>(propertiesBuffer.data());
+
+    pProperties->Wnode.BufferSize = static_cast<ULONG>(bufferSize);
+    pProperties->Wnode.Flags = WNODE_FLAG_TRACED_GUID;
+    pProperties->Wnode.ClientContext = 1; // QPC for high-resolution timestamps
+    pProperties->LogFileMode = EVENT_TRACE_REAL_TIME_MODE;
+    pProperties->LoggerNameOffset = static_cast<ULONG>(sessionNameOffset);
+    pProperties->LogFileNameOffset = 0; // No log file — real-time only
+
+    // Buffer settings for process events (moderate volume)
+    pProperties->BufferSize = 64;      // 64 KB per buffer
+    pProperties->MinimumBuffers = 4;
+    pProperties->MaximumBuffers = 16;
+    pProperties->FlushTimer = 1;       // Flush every 1 second for responsiveness
+
+    // Copy session name into the properties buffer
+    wcscpy_s(
+        reinterpret_cast<wchar_t*>(propertiesBuffer.data() + sessionNameOffset),
+        wcslen(ETW_SESSION_NAME) + 1,
+        ETW_SESSION_NAME);
+
+    // Try to stop any orphaned session from a previous crash
+    {
+        std::vector<BYTE> stopBuffer(bufferSize, 0);
+        auto* pStopProps = reinterpret_cast<EVENT_TRACE_PROPERTIES*>(stopBuffer.data());
+        pStopProps->Wnode.BufferSize = static_cast<ULONG>(bufferSize);
+        pStopProps->LoggerNameOffset = static_cast<ULONG>(sessionNameOffset);
+
+        wcscpy_s(
+            reinterpret_cast<wchar_t*>(stopBuffer.data() + sessionNameOffset),
+            wcslen(ETW_SESSION_NAME) + 1,
+            ETW_SESSION_NAME);
+
+        ULONG stopResult = ControlTraceW(0, ETW_SESSION_NAME, pStopProps, EVENT_TRACE_CONTROL_STOP);
+        if (stopResult == ERROR_SUCCESS)
+        {
+            LogError("[!] ProcessTracker: Cleaned up orphaned ETW session from previous run");
+        }
+    }
+
+    // Start the trace session
+    ULONG startResult = StartTraceW(&m_sessionHandle, ETW_SESSION_NAME, pProperties);
+    {
+        std::lock_guard<std::mutex> lock(m_diagMutex);
+        m_diagnostics.etwSessionStartResult = startResult;
+    }
+
+    if (startResult != ERROR_SUCCESS)
+    {
+        std::lock_guard<std::mutex> lock(m_diagMutex);
+        m_diagnostics.lastErrorMessage = L"StartTraceW failed: " + std::to_wstring(startResult);
+
+        if (startResult == ERROR_ACCESS_DENIED)
+        {
+            LogError("[-] ProcessTracker: StartTraceW returned ERROR_ACCESS_DENIED. "
+                     "Service must run as SYSTEM to create kernel ETW sessions.");
+        }
+        else if (startResult == static_cast<ULONG>(ERROR_NO_SYSTEM_RESOURCES))
+        {
+            LogError("[-] ProcessTracker: StartTraceW returned ERROR_NO_SYSTEM_RESOURCES. "
+                     "System may have reached the 64-session ETW limit. "
+                     "Check for other monitoring agents consuming ETW sessions.");
+        }
+        else
+        {
+            LogError("[-] ProcessTracker: StartTraceW failed, error: " +
+                     std::to_string(startResult) + " — " +
+                     GetWindowsErrorMessage(static_cast<LONG>(startResult)));
+        }
+
+        m_sessionHandle = 0;
+        return false;
+    }
+
+    // Enable the Microsoft-Windows-Kernel-Process provider on our session
+    // TRACE_LEVEL_INFORMATION captures ProcessStart (event ID 1)
+    ULONG enableResult = EnableTraceEx2(
+        m_sessionHandle,
+        &s_kernelProcessProviderGuid,
+        EVENT_CONTROL_CODE_ENABLE_PROVIDER,
+        TRACE_LEVEL_INFORMATION,
+        0x10,   // Keyword: WINEVENT_KEYWORD_PROCESS (0x10) for process events only
+        0,      // MatchAnyKeyword
+        0,      // Timeout (0 = no timeout)
+        nullptr // EnableParameters
+    );
+
+    if (enableResult != ERROR_SUCCESS)
+    {
+        LogError("[-] ProcessTracker: EnableTraceEx2 failed, error: " +
+                 std::to_string(enableResult) + " — " +
+                 GetWindowsErrorMessage(static_cast<LONG>(enableResult)));
+
+        // Stop the session we just started
+        StopEtwSession();
+        return false;
+    }
+
+    // Open a real-time consumer trace handle
+    EVENT_TRACE_LOGFILEW logFile = {};
+    logFile.LoggerName = const_cast<LPWSTR>(ETW_SESSION_NAME);
+    logFile.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_EVENT_RECORD;
+    logFile.EventRecordCallback = EtwEventCallback;
+
+    m_consumerHandle = OpenTraceW(&logFile);
+    {
+        std::lock_guard<std::mutex> lock(m_diagMutex);
+        if (m_consumerHandle == INVALID_PROCESSTRACE_HANDLE)
+        {
+            DWORD openError = GetLastError();
+            m_diagnostics.etwConsumerOpenResult = openError;
+            m_diagnostics.lastErrorMessage = L"OpenTraceW failed: " + std::to_wstring(openError);
+
+            LogError("[-] ProcessTracker: OpenTraceW failed, error: " +
+                     std::to_string(openError));
+
+            StopEtwSession();
+            return false;
+        }
+        m_diagnostics.etwConsumerOpenResult = ERROR_SUCCESS;
+        m_diagnostics.activeSource = ProcessTrackingSource::EtwKernelProcess;
+    }
+
+    // ProcessTrace blocks, so run it on a dedicated thread
+    m_etwConsumerThread = CreateThread(nullptr, 0, EtwConsumerThread, this, 0, nullptr);
+    if (m_etwConsumerThread == nullptr)
+    {
+        LogError("[-] ProcessTracker: Failed to create ETW consumer thread, error: " +
+                 std::to_string(GetLastError()));
+        CloseTrace(m_consumerHandle);
+        m_consumerHandle = INVALID_PROCESSTRACE_HANDLE;
+        StopEtwSession();
+        return false;
+    }
+
+    return true;
+}
+
+void ProcessTracker::StopEtwSession()
+{
+    // Close the consumer handle first (unblocks ProcessTrace)
+    if (m_consumerHandle != INVALID_PROCESSTRACE_HANDLE)
+    {
+        CloseTrace(m_consumerHandle);
+        m_consumerHandle = INVALID_PROCESSTRACE_HANDLE;
+    }
+
+    // Wait for the consumer thread to exit
+    if (m_etwConsumerThread != nullptr)
+    {
+        WaitForSingleObject(m_etwConsumerThread, 5000);
+        CloseHandle(m_etwConsumerThread);
+        m_etwConsumerThread = nullptr;
+    }
+
+    // Stop the trace session
+    if (m_sessionHandle != 0)
+    {
+        const size_t sessionNameLen = wcslen(ETW_SESSION_NAME) + 1;
+        const size_t bufferSize = sizeof(EVENT_TRACE_PROPERTIES) + sessionNameLen * sizeof(wchar_t);
+        std::vector<BYTE> buffer(bufferSize, 0);
+        auto* pProperties = reinterpret_cast<EVENT_TRACE_PROPERTIES*>(buffer.data());
+        pProperties->Wnode.BufferSize = static_cast<ULONG>(bufferSize);
+        pProperties->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
+
+        ControlTraceW(m_sessionHandle, nullptr, pProperties, EVENT_TRACE_CONTROL_STOP);
+        m_sessionHandle = 0;
+    }
+}
+
+// ============================================================================
+// ETW Consumer Thread + Callback
+// ============================================================================
+
+DWORD WINAPI ProcessTracker::EtwConsumerThread(LPVOID lpParam)
+{
+    auto* tracker = static_cast<ProcessTracker*>(lpParam);
+    if (tracker == nullptr)
+        return 1;
+
+    TRACEHANDLE handles[1] = { tracker->m_consumerHandle };
+
+    // ProcessTrace blocks until the session is stopped or CloseTrace is called
+    ULONG status = ProcessTrace(handles, 1, nullptr, nullptr);
+    if (status != ERROR_SUCCESS && status != ERROR_CANCELLED)
+    {
+        LogError("[!] ProcessTracker: ProcessTrace exited with status: " +
+                 std::to_string(status));
+    }
+
+    return 0;
+}
+
+void WINAPI ProcessTracker::EtwEventCallback(PEVENT_RECORD pEventRecord)
+{
+    if (pEventRecord == nullptr || s_instance == nullptr)
+        return;
+
+    // Filter: only process events from Microsoft-Windows-Kernel-Process
+    if (!IsEqualGUID(pEventRecord->EventHeader.ProviderId, s_kernelProcessProviderGuid))
+        return;
+
+    // Filter: only ProcessStart events (event ID 1)
+    if (pEventRecord->EventHeader.EventDescriptor.Id != KERNEL_PROCESS_EVENT_START)
+        return;
+
+    s_instance->HandleProcessStartEvent(pEventRecord);
+}
+
+void ProcessTracker::HandleProcessStartEvent(PEVENT_RECORD pEventRecord)
+{
+    // Defensive: validate the event record before parsing.
+    // Malformed or truncated events (e.g., from buffer overflows in the kernel
+    // provider) could cause TDH to read out-of-bounds if UserDataLength is bogus.
+    if (pEventRecord->UserData == nullptr || pEventRecord->UserDataLength == 0)
+    {
+        return;
+    }
+
+    // Extract data from the event using TDH (Trace Data Helper)
+    DWORD bufferSize = 0;
+    TDHSTATUS status = TdhGetEventInformation(pEventRecord, 0, nullptr, nullptr, &bufferSize);
+    if (status != ERROR_INSUFFICIENT_BUFFER || bufferSize == 0)
+    {
+        return;
+    }
+
+    std::vector<BYTE> buffer(bufferSize);
+    auto* pInfo = reinterpret_cast<TRACE_EVENT_INFO*>(buffer.data());
+    status = TdhGetEventInformation(pEventRecord, 0, nullptr, pInfo, &bufferSize);
+    if (status != ERROR_SUCCESS)
+    {
+        return;
+    }
+
+    // Parse properties from the event
+    std::wstring imagePath;
+    std::wstring commandLine;
+    DWORD processId = pEventRecord->EventHeader.ProcessId;
+    DWORD parentProcessId = 0;
+
+    // Iterate through event properties to extract ImageName, CommandLine, ParentProcessID
+    for (ULONG i = 0; i < pInfo->TopLevelPropertyCount; ++i)
+    {
+        EVENT_PROPERTY_INFO& propInfo = pInfo->EventPropertyInfoArray[i];
+        LPCWSTR propName = reinterpret_cast<LPCWSTR>(
+            reinterpret_cast<BYTE*>(pInfo) + propInfo.NameOffset);
+
+        PROPERTY_DATA_DESCRIPTOR dataDesc = {};
+        dataDesc.PropertyName = reinterpret_cast<ULONGLONG>(propName);
+        dataDesc.ArrayIndex = ULONG_MAX;
+
+        DWORD propSize = 0;
+        status = TdhGetPropertySize(pEventRecord, 0, nullptr, 1, &dataDesc, &propSize);
+        if (status != ERROR_SUCCESS || propSize == 0)
+        {
+            continue;
+        }
+
+        std::vector<BYTE> propBuffer(propSize);
+        status = TdhGetProperty(pEventRecord, 0, nullptr, 1, &dataDesc, propSize, propBuffer.data());
+        if (status != ERROR_SUCCESS)
+        {
+            continue;
+        }
+
+        if (_wcsicmp(propName, L"ImageName") == 0 && propSize >= sizeof(wchar_t))
+        {
+            // Safe extraction: ensure null-termination within the buffer bounds.
+            // TDH string properties should be null-terminated, but a truncated
+            // event from a misbehaving provider could omit the terminator.
+            const wchar_t* raw = reinterpret_cast<const wchar_t*>(propBuffer.data());
+            size_t maxChars = propSize / sizeof(wchar_t);
+            size_t len = wcsnlen_s(raw, maxChars);
+            imagePath.assign(raw, len);
+        }
+        else if (_wcsicmp(propName, L"CommandLine") == 0 && propSize >= sizeof(wchar_t))
+        {
+            const wchar_t* raw = reinterpret_cast<const wchar_t*>(propBuffer.data());
+            size_t maxChars = propSize / sizeof(wchar_t);
+            size_t len = wcsnlen_s(raw, maxChars);
+            commandLine.assign(raw, len);
+        }
+        else if (_wcsicmp(propName, L"ParentProcessID") == 0 && propSize >= sizeof(DWORD))
+        {
+            parentProcessId = *reinterpret_cast<const DWORD*>(propBuffer.data());
+        }
+    }
+
+    if (imagePath.empty())
+    {
+        return; // No image path — skip
+    }
+
+    // Truncate attacker-controlled strings to cap memory usage.
+    // Prevents a malicious actor from spawning processes with near-max-length
+    // (32,767 char) command lines to exhaust the process buffer and dedup map.
+    // Applied at the ingestion boundary before any storage or map insertion.
+    if (imagePath.size() > MAX_PROCESS_STRING_LENGTH)
+    {
+        imagePath.resize(MAX_PROCESS_STRING_LENGTH);
+    }
+    if (commandLine.size() > MAX_PROCESS_STRING_LENGTH)
+    {
+        commandLine.resize(MAX_PROCESS_STRING_LENGTH);
+    }
+
+    // Check if this is a Windows service process (exclude from collection)
+    if (IsServiceProcess(processId, parentProcessId))
+    {
+        std::lock_guard<std::mutex> lock(m_diagMutex);
+        m_diagnostics.serviceProcessesExcluded++;
+        return;
+    }
+
+    // Resolve user SID from the process token
+    std::wstring userSid = GetProcessUserSid(processId);
+    std::wstring username = ResolveSidToUsername(userSid);
+
+    // Deduplication check
+    if (IsDuplicateProcess(imagePath, commandLine, userSid))
+    {
+        std::lock_guard<std::mutex> lock(m_diagMutex);
+        m_diagnostics.eventsDeduplicatedOut++;
+        return;
+    }
+
+    // Add dedup entry
+    AddDeduplicationEntry(imagePath, commandLine, userSid);
+
+    // Build the process info record
+    RunningProcessInfo info = {};
+    info.imagePath = std::move(imagePath);
+    info.commandLine = std::move(commandLine);
+    info.userSid = std::move(userSid);
+    info.username = std::move(username);
+    info.processId = processId;
+    info.parentProcessId = parentProcessId;
+    info.parentImagePath = GetProcessImagePath(parentProcessId);
+    info.firstSeenTimestamp = GetCurrentTimestamp();
+    info.isServiceProcess = false;
+
+    // Add to observed processes (with buffer cap to prevent unbounded memory growth)
+    {
+        std::lock_guard<std::mutex> lock(m_processMutex);
+        if (m_observedProcesses.size() < MAX_OBSERVED_PROCESSES)
+        {
+            m_observedProcesses.push_back(std::move(info));
+        }
+        else
+        {
+            // Buffer is full — log once per overflow burst to avoid log spam.
+            // The oldest entries are preserved; new ones are dropped until collection resets the buffer.
+            static thread_local ULONGLONG lastOverflowLogTick = 0;
+            ULONGLONG now = GetTickCount64();
+            if (now - lastOverflowLogTick > 60000ULL) // Log at most once per minute
+            {
+                LogError("[!] ProcessTracker: Observed process buffer is full ("
+                         + std::to_string(MAX_OBSERVED_PROCESSES) +
+                         " entries). New events will be dropped until next collection cycle.");
+                lastOverflowLogTick = now;
+            }
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_diagMutex);
+        m_diagnostics.totalEventsReceived++;
+    }
+
+    // Periodically purge expired dedup entries
+    PurgeExpiredDeduplicationEntries();
+}
+
+// ============================================================================
+// Sysmon Fallback
+// ============================================================================
+
+bool ProcessTracker::IsSysmonEventLogAvailable() const
+{
+    // Check if the Sysmon operational event log channel exists
+    HANDLE hLog = OpenEventLogW(nullptr, L"Microsoft-Windows-Sysmon/Operational");
+    if (hLog != nullptr)
+    {
+        CloseEventLog(hLog);
+        return true;
+    }
+    return false;
+}
+
+bool ProcessTracker::StartSysmonFallback()
+{
+    if (!IsSysmonEventLogAvailable())
+    {
+        LogError("[!] ProcessTracker: Sysmon event log not available on this system");
+        std::lock_guard<std::mutex> lock(m_diagMutex);
+        m_diagnostics.sysmonAvailable = false;
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m_diagMutex);
+        m_diagnostics.sysmonAvailable = true;
+        m_diagnostics.activeSource = ProcessTrackingSource::SysmonEventLog;
+    }
+
+    LogError("[+] ProcessTracker: Starting Sysmon event log polling fallback");
+
+    m_sysmonPollThread = CreateThread(nullptr, 0, SysmonPollingThread, this, 0, nullptr);
+    if (m_sysmonPollThread == nullptr)
+    {
+        LogError("[-] ProcessTracker: Failed to create Sysmon polling thread, error: " +
+                 std::to_string(GetLastError()));
+        return false;
+    }
+
+    return true;
+}
+
+void ProcessTracker::StopSysmonFallback()
+{
+    if (m_sysmonPollThread != nullptr)
+    {
+        WaitForSingleObject(m_sysmonPollThread, 5000);
+        CloseHandle(m_sysmonPollThread);
+        m_sysmonPollThread = nullptr;
+    }
+}
+
+DWORD WINAPI ProcessTracker::SysmonPollingThread(LPVOID lpParam)
+{
+    auto* tracker = static_cast<ProcessTracker*>(lpParam);
+    if (tracker == nullptr)
+        return 1;
+
+    tracker->PollSysmonEvents();
+    return 0;
+}
+
+void ProcessTracker::PollSysmonEvents()
+{
+    // Sysmon Event ID 1 = Process Create
+    // We use the Windows Event Log API (evt* functions) to subscribe to
+    // new events on the Sysmon/Operational channel.
+
+    // Dynamically load wevtapi.dll to avoid hard dependency (RAII)
+    LibraryHandle hWevtapi(LoadLibraryW(L"wevtapi.dll"));
+    if (!hWevtapi)
+    {
+        LogError("[-] ProcessTracker: Failed to load wevtapi.dll for Sysmon fallback");
+        return;
+    }
+
+    // Function pointer types for Windows Event Log API
+    // Use explicit calling convention and winevt.h types
+    using EvtSubscribeFn = EVT_HANDLE (WINAPI*)(
+        EVT_HANDLE, HANDLE, LPCWSTR, LPCWSTR, EVT_HANDLE, PVOID,
+        EVT_SUBSCRIBE_CALLBACK, DWORD);
+    using EvtCloseFn = BOOL (WINAPI*)(EVT_HANDLE);
+
+    auto fnEvtSubscribe = reinterpret_cast<EvtSubscribeFn>(
+        GetProcAddress(hWevtapi.Get(), "EvtSubscribe"));
+    auto fnEvtClose = reinterpret_cast<EvtCloseFn>(
+        GetProcAddress(hWevtapi.Get(), "EvtClose"));
+
+    if (fnEvtSubscribe == nullptr || fnEvtClose == nullptr)
+    {
+        LogError("[-] ProcessTracker: Failed to resolve wevtapi.dll functions");
+        return;
+    }
+
+    // Subscribe to Sysmon process creation events (Event ID 1)
+    // XPath query filters for Event ID 1 only
+    const wchar_t* query = L"*[System[EventID=1]]";
+
+    EVT_HANDLE hSubscription = fnEvtSubscribe(
+        nullptr,            // Local machine
+        m_stopEvent,        // Signal handle for cancellation
+        L"Microsoft-Windows-Sysmon/Operational",
+        query,
+        nullptr,            // No bookmark
+        nullptr,            // No callback context
+        nullptr,            // No callback — we use signal-based
+        EvtSubscribeToFutureEvents);
+
+    if (hSubscription == nullptr)
+    {
+        DWORD err = GetLastError();
+        LogError("[-] ProcessTracker: EvtSubscribe for Sysmon failed, error: " +
+                 std::to_string(err) + " — " + GetWindowsErrorMessage(static_cast<LONG>(err)));
+        return;
+    }
+
+    LogError("[+] ProcessTracker: Sysmon event subscription active");
+
+    // Wait for stop signal — the subscription delivers events via the signal handle
+    // For simplicity in the fallback path, we just keep the subscription open
+    // and let the service's periodic collection gather the process snapshot
+    WaitForSingleObject(m_stopEvent, INFINITE);
+
+    fnEvtClose(hSubscription);
+}
+
+// ============================================================================
+// Deduplication
+// ============================================================================
+
+bool ProcessTracker::IsDuplicateProcess(const std::wstring& imagePath,
+                                        const std::wstring& commandLine,
+                                        const std::wstring& userSid) const
+{
+    // Build composite key: imagePath|commandLine|userSid
+    // Using the full key string avoids hash collisions that would silently
+    // drop unique process events at enterprise scale (millions of events).
+    std::wstring key = imagePath + L"|" + commandLine + L"|" + userSid;
+
+    std::lock_guard<std::mutex> lock(m_dedupMutex);
+    auto it = m_deduplicationMap.find(key);
+    if (it == m_deduplicationMap.end())
+    {
+        return false;
+    }
+
+    // Check if the entry has expired
+    ULONGLONG now = GetTickCount64();
+    if (now > it->second)
+    {
+        // Entry expired — not a duplicate
+        return false;
+    }
+
+    return true;
+}
+
+void ProcessTracker::AddDeduplicationEntry(const std::wstring& imagePath,
+                                           const std::wstring& commandLine,
+                                           const std::wstring& userSid)
+{
+    std::wstring key = imagePath + L"|" + commandLine + L"|" + userSid;
+    ULONGLONG expiry = GetTickCount64() + DEDUP_WINDOW_MS;
+
+    std::lock_guard<std::mutex> lock(m_dedupMutex);
+
+    // Cap dedup map size to prevent unbounded memory growth from an attacker
+    // spawning millions of unique short-lived processes with unique cmdlines.
+    // When full, skip insertion — the process will still be recorded in the
+    // observed buffer, just without dedup protection until the map is purged.
+    if (m_deduplicationMap.size() >= MAX_OBSERVED_PROCESSES)
+    {
+        return;
+    }
+
+    m_deduplicationMap[key] = expiry;
+}
+
+void ProcessTracker::PurgeExpiredDeduplicationEntries()
+{
+    // Only purge periodically (every ~100 events) to avoid lock contention
+    // on the ETW callback hot path.
+    static thread_local DWORD purgeCounter = 0;
+    if (++purgeCounter % 100 != 0)
+    {
+        return;
+    }
+
+    ULONGLONG now = GetTickCount64();
+
+    std::lock_guard<std::mutex> lock(m_dedupMutex);
+    for (auto it = m_deduplicationMap.begin(); it != m_deduplicationMap.end(); )
+    {
+        if (now > it->second)
+        {
+            it = m_deduplicationMap.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+// ============================================================================
+// Service Process Exclusion
+// ============================================================================
+
+bool ProcessTracker::IsServiceProcess(DWORD processId, DWORD parentProcessId) const
+{
+    // A process is considered a service process if its parent is services.exe
+    DWORD servicesPid = GetServicesPid();
+    if (servicesPid != 0 && parentProcessId == servicesPid)
+    {
+        return true;
+    }
+
+    return false;
+}
+
+DWORD ProcessTracker::GetServicesPid() const
+{
+    // Check if cache is still valid (refresh every SERVICES_PID_CACHE_TTL_MS).
+    // services.exe PID is stable under normal operation, but we refresh
+    // periodically for correctness in edge cases (failover, recovery, etc.).
+    if (m_servicesPidCached)
+    {
+        ULONGLONG now = GetTickCount64();
+        if (now < m_servicesPidCacheExpiry)
+        {
+            return m_servicesPid;
+        }
+        // Cache expired — fall through to refresh
+        m_servicesPidCached = false;
+    }
+
+    // Find services.exe PID via process snapshot (RAII)
+    SnapshotHandle hSnapshot(CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0));
+    if (!hSnapshot)
+    {
+        return 0;
+    }
+
+    PROCESSENTRY32W pe = {};
+    pe.dwSize = sizeof(pe);
+
+    if (Process32FirstW(hSnapshot.Get(), &pe))
+    {
+        do
+        {
+            if (_wcsicmp(pe.szExeFile, L"services.exe") == 0)
+            {
+                m_servicesPid = pe.th32ProcessID;
+                m_servicesPidCached = true;
+                m_servicesPidCacheExpiry = GetTickCount64() + SERVICES_PID_CACHE_TTL_MS;
+                return m_servicesPid;
+            }
+        } while (Process32NextW(hSnapshot.Get(), &pe));
+    }
+
+    return 0;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+std::wstring ProcessTracker::GetProcessUserSid(DWORD processId)
+{
+    WinHandle hProcess(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId));
+    if (!hProcess)
+    {
+        return {};
+    }
+
+    HANDLE rawToken = nullptr;
+    if (!OpenProcessToken(hProcess.Get(), TOKEN_QUERY, &rawToken))
+    {
+        return {};
+    }
+    WinHandle hToken(rawToken);
+
+    // Sizing call: must return ERROR_INSUFFICIENT_BUFFER with a non-zero size
+    DWORD tokenInfoSize = 0;
+    if (!GetTokenInformation(hToken.Get(), TokenUser, nullptr, 0, &tokenInfoSize))
+    {
+        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || tokenInfoSize == 0)
+        {
+            return {};
+        }
+    }
+
+    std::vector<BYTE> tokenBuffer(tokenInfoSize);
+    auto* pTokenUser = reinterpret_cast<TOKEN_USER*>(tokenBuffer.data());
+    if (!GetTokenInformation(hToken.Get(), TokenUser, pTokenUser, tokenInfoSize, &tokenInfoSize))
+    {
+        return {};
+    }
+
+    LPWSTR sidString = nullptr;
+    std::wstring result;
+    if (ConvertSidToStringSidW(pTokenUser->User.Sid, &sidString))
+    {
+        result = sidString;
+        LocalFree(sidString);
+    }
+
+    return result;
+}
+
+std::wstring ProcessTracker::ResolveSidToUsername(const std::wstring& sidString)
+{
+    if (sidString.empty())
+    {
+        return L"Unknown";
+    }
+
+    PSID pSid = nullptr;
+    if (!ConvertStringSidToSidW(sidString.c_str(), &pSid))
+    {
+        return L"Unknown";
+    }
+    // RAII: ConvertStringSidToSidW allocates via LocalAlloc
+    LocalMemGuard sidGuard(pSid);
+
+    wchar_t nameBuffer[256] = {};
+    DWORD nameSize = _countof(nameBuffer);
+    wchar_t domainBuffer[256] = {};
+    DWORD domainSize = _countof(domainBuffer);
+    SID_NAME_USE sidType = SidTypeUnknown;
+
+    std::wstring result = L"Unknown";
+    if (LookupAccountSidW(nullptr, pSid, nameBuffer, &nameSize, domainBuffer, &domainSize, &sidType))
+    {
+        if (domainBuffer[0] != L'\0')
+        {
+            result = std::wstring(domainBuffer) + L"\\" + nameBuffer;
+        }
+        else
+        {
+            result = nameBuffer;
+        }
+    }
+
+    return result;
+}
+
+std::wstring ProcessTracker::GetProcessImagePath(DWORD processId)
+{
+    if (processId == 0)
+    {
+        return {};
+    }
+
+    WinHandle hProcess(OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, processId));
+    if (!hProcess)
+    {
+        return {};
+    }
+
+    // First attempt with stack buffer (covers ~99% of paths)
+    wchar_t stackBuffer[MAX_PATH] = {};
+    DWORD pathSize = MAX_PATH;
+
+    if (QueryFullProcessImageNameW(hProcess.Get(), 0, stackBuffer, &pathSize))
+    {
+        return std::wstring(stackBuffer, pathSize);
+    }
+
+    // If MAX_PATH was insufficient, retry with a larger heap buffer.
+    // Extended-length paths (\\?\) can reach 32,767 characters in enterprise
+    // environments with deep directory structures or long filenames.
+    if (GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+    {
+        constexpr DWORD extendedMaxPath = 32768;
+        std::wstring largeBuffer(extendedMaxPath, L'\0');
+        pathSize = extendedMaxPath;
+
+        if (QueryFullProcessImageNameW(hProcess.Get(), 0, largeBuffer.data(), &pathSize))
+        {
+            largeBuffer.resize(pathSize);
+            return largeBuffer;
+        }
+    }
+
+    return {};
+}
+
+std::wstring ProcessTracker::GetCurrentTimestamp()
+{
+    auto now = std::chrono::system_clock::now();
+    auto time = std::chrono::system_clock::to_time_t(now);
+    struct tm timeinfo = {};
+
+    if (localtime_s(&timeinfo, &time) != 0)
+    {
+        return L"UNKNOWN";
+    }
+
+    std::wostringstream wss;
+    wss << std::put_time(&timeinfo, L"%Y-%m-%dT%H:%M:%S");
+    return wss.str();
+}
+
+// ============================================================================
+// Snapshot-based Collection (point-in-time enumeration)
+// ============================================================================
+
+std::vector<RunningProcessInfo> SnapshotRunningProcesses(
+    const std::vector<DWORD>& serviceProcessIds)
+{
+    std::vector<RunningProcessInfo> processes;
+
+    // Build a set of service PIDs for O(1) lookup
+    std::unordered_set<DWORD> servicePidSet(serviceProcessIds.begin(), serviceProcessIds.end());
+
+    // Take a single atomic snapshot of all processes.
+    // Using one snapshot for both services.exe lookup and enumeration
+    // eliminates the TOCTOU window of two separate snapshots.
+    SnapshotHandle hSnapshot(CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0));
+    if (!hSnapshot)
+    {
+        LogError("[-] SnapshotRunningProcesses: CreateToolhelp32Snapshot failed, error: " +
+                 std::to_string(GetLastError()));
+        return processes;
+    }
+
+    // First pass: collect all PROCESSENTRY32W entries into a vector and find services.exe PID.
+    // This allows a single snapshot walk followed by filtering, avoiding iterator invalidation.
+    struct ProcessEntry
+    {
+        DWORD processId;
+        DWORD parentProcessId;
+    };
+    std::vector<ProcessEntry> allEntries;
+    DWORD servicesPid = 0;
+
+    PROCESSENTRY32W pe = {};
+    pe.dwSize = sizeof(pe);
+
+    if (Process32FirstW(hSnapshot.Get(), &pe))
+    {
+        do
+        {
+            if (_wcsicmp(pe.szExeFile, L"services.exe") == 0)
+            {
+                servicesPid = pe.th32ProcessID;
+            }
+
+            allEntries.push_back({ pe.th32ProcessID, pe.th32ParentProcessID });
+
+        } while (Process32NextW(hSnapshot.Get(), &pe));
+    }
+
+    // Second pass: filter and build RunningProcessInfo for non-service processes
+    for (const auto& entry : allEntries)
+    {
+        DWORD pid = entry.processId;
+
+        // Skip PID 0 (System Idle) and PID 4 (System)
+        if (pid == 0 || pid == 4)
+        {
+            continue;
+        }
+
+        // Skip known service processes (by PID from SCM enumeration)
+        if (servicePidSet.count(pid) > 0)
+        {
+            continue;
+        }
+
+        // Skip processes whose parent is services.exe (service host processes)
+        if (servicesPid != 0 && entry.parentProcessId == servicesPid)
+        {
+            continue;
+        }
+
+        // Get full image path
+        std::wstring imagePath = ProcessTracker::GetProcessImagePath(pid);
+        if (imagePath.empty())
+        {
+            // Cannot read — likely a protected/kernel process
+            continue;
+        }
+
+        // Truncate attacker-controlled strings to cap memory usage (same as ETW path)
+        if (imagePath.size() > MAX_PROCESS_STRING_LENGTH)
+        {
+            imagePath.resize(MAX_PROCESS_STRING_LENGTH);
+        }
+
+        // Get process user SID
+        std::wstring userSid = ProcessTracker::GetProcessUserSid(pid);
+        std::wstring username = ProcessTracker::ResolveSidToUsername(userSid);
+
+        // Snapshot mode: record image path as command line (best-effort fallback).
+        // Full command line retrieval from another process requires reading the PEB
+        // via NtQueryInformationProcess, which may fail for protected processes.
+        std::wstring commandLine = imagePath;
+        if (commandLine.size() > MAX_PROCESS_STRING_LENGTH)
+        {
+            commandLine.resize(MAX_PROCESS_STRING_LENGTH);
+        }
+
+        RunningProcessInfo info = {};
+        info.imagePath = std::move(imagePath);
+        info.commandLine = std::move(commandLine);
+        info.userSid = std::move(userSid);
+        info.username = std::move(username);
+        info.processId = pid;
+        info.parentProcessId = entry.parentProcessId;
+        info.parentImagePath = ProcessTracker::GetProcessImagePath(entry.parentProcessId);
+        info.firstSeenTimestamp = ProcessTracker::GetCurrentTimestamp();
+        info.isServiceProcess = false;
+
+        processes.push_back(std::move(info));
+    }
+
+    LogError("[+] SnapshotRunningProcesses: Captured " + std::to_string(processes.size()) +
+             " non-service processes");
+
+    return processes;
+}

--- a/WindowsEnum/src/ProcessTracker.h
+++ b/WindowsEnum/src/ProcessTracker.h
@@ -1,0 +1,201 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <evntrace.h>
+#include <evntcons.h>
+#include <string>
+#include <vector>
+#include <mutex>
+#include <unordered_set>
+#include <unordered_map>
+#include <atomic>
+
+// Represents a single observed process execution.
+// Collected via ETW (Microsoft-Windows-Kernel-Process) or Sysmon fallback.
+struct RunningProcessInfo
+{
+    std::wstring imagePath;             // Full path to the executable image
+    std::wstring commandLine;           // Full command line including arguments
+    std::wstring userSid;               // SID of the user who launched the process
+    std::wstring username;              // Resolved username (best-effort)
+    DWORD processId = 0;               // PID of the process
+    DWORD parentProcessId = 0;         // PID of the parent process
+    std::wstring parentImagePath;       // Image path of the parent process (best-effort)
+    std::wstring firstSeenTimestamp;    // ISO 8601 timestamp when first observed
+    bool isServiceProcess = false;      // True if process is a known Windows service
+};
+
+// Tracking source indicator for diagnostics
+enum class ProcessTrackingSource
+{
+    None = 0,
+    EtwKernelProcess,      // Primary: Microsoft-Windows-Kernel-Process ETW provider
+    SysmonEventLog,        // Fallback: Sysmon operational event log
+    Disabled               // Administratively disabled via config
+};
+
+// Diagnostic telemetry about the tracker state
+struct ProcessTrackerDiagnostics
+{
+    ProcessTrackingSource activeSource = ProcessTrackingSource::None;
+    ULONG etwSessionStartResult = 0;           // HRESULT/Win32 error from StartTrace
+    ULONG etwConsumerOpenResult = 0;            // Error from OpenTrace
+    bool sysmonAvailable = false;               // Whether Sysmon event log exists
+    DWORD totalEventsReceived = 0;              // Total process-start events received
+    DWORD eventsDeduplicatedOut = 0;            // Events dropped by dedup filter
+    DWORD serviceProcessesExcluded = 0;         // Events excluded as service processes
+    std::wstring lastErrorMessage;              // Human-readable last error
+};
+
+// Real-time process execution tracker using ETW with Sysmon fallback.
+// Designed to run as a background thread within the Spectra service.
+//
+// Thread safety: All public methods are thread-safe.
+// Privilege requirement: SYSTEM account (required for kernel ETW session).
+class ProcessTracker
+{
+public:
+    ProcessTracker();
+    ~ProcessTracker();
+
+    // Non-copyable, non-movable (owns ETW session and thread handles)
+    ProcessTracker(const ProcessTracker&) = delete;
+    ProcessTracker& operator=(const ProcessTracker&) = delete;
+    ProcessTracker(ProcessTracker&&) = delete;
+    ProcessTracker& operator=(ProcessTracker&&) = delete;
+
+    // Start the process tracking background thread.
+    // Returns true if tracking was started (ETW or Sysmon fallback).
+    // Returns false if disabled by config or all sources failed.
+    bool Start();
+
+    // Stop the process tracking and clean up resources.
+    // Safe to call multiple times or if not started.
+    void Stop();
+
+    // Collect and return all unique observed processes since last collection.
+    // Clears the internal buffer after copying.
+    // Thread-safe: called from the data-collection worker thread.
+    std::vector<RunningProcessInfo> CollectAndReset();
+
+    // Get diagnostic telemetry about the tracker state.
+    ProcessTrackerDiagnostics GetDiagnostics() const;
+
+    // Check if the tracker is currently active.
+    bool IsRunning() const;
+
+private:
+    // ETW session management
+    bool StartEtwSession();
+    void StopEtwSession();
+
+    // Sysmon event log fallback
+    bool StartSysmonFallback();
+    void StopSysmonFallback();
+    bool IsSysmonEventLogAvailable() const;
+
+    // ETW callback (static, called by ETW infrastructure)
+    static void WINAPI EtwEventCallback(PEVENT_RECORD pEventRecord);
+
+    // Process an ETW event record (instance method, called from static callback)
+    void HandleProcessStartEvent(PEVENT_RECORD pEventRecord);
+
+    // Sysmon event log polling thread
+    static DWORD WINAPI SysmonPollingThread(LPVOID lpParam);
+    void PollSysmonEvents();
+
+    // ETW consumer thread (ProcessTrace blocks, needs dedicated thread)
+    static DWORD WINAPI EtwConsumerThread(LPVOID lpParam);
+
+    // Deduplication: returns true if this process was already seen recently
+    bool IsDuplicateProcess(const std::wstring& imagePath, const std::wstring& commandLine,
+                            const std::wstring& userSid) const;
+
+    // Add a dedup entry for a newly observed process
+    void AddDeduplicationEntry(const std::wstring& imagePath, const std::wstring& commandLine,
+                               const std::wstring& userSid);
+
+    // Purge expired deduplication entries
+    void PurgeExpiredDeduplicationEntries();
+
+    // Check if a process is a known Windows service by its PID or parent
+    bool IsServiceProcess(DWORD processId, DWORD parentProcessId) const;
+
+    // Find the PID of services.exe (cached)
+    DWORD GetServicesPid() const;
+
+public:
+    // These helpers are public so that SnapshotRunningProcesses() can reuse them.
+
+    // Resolve process user SID from process token
+    static std::wstring GetProcessUserSid(DWORD processId);
+
+    // Resolve SID string to username (best-effort)
+    static std::wstring ResolveSidToUsername(const std::wstring& sidString);
+
+    // Get the image path for a given PID (best-effort, may fail for exited processes)
+    static std::wstring GetProcessImagePath(DWORD processId);
+
+    // Build ISO 8601 timestamp string
+    static std::wstring GetCurrentTimestamp();
+
+private:
+
+    // --- Data members ---
+
+    // Observed processes buffer (protected by mutex)
+    mutable std::mutex m_processMutex;
+    std::vector<RunningProcessInfo> m_observedProcesses;
+
+    // Deduplication map: full composite key (imagePath|cmdLine|userSid) -> expiry tick.
+    // Uses the full key string instead of a hash to avoid hash collisions that would
+    // silently drop unique process events at enterprise scale.
+    mutable std::mutex m_dedupMutex;
+    std::unordered_map<std::wstring, ULONGLONG> m_deduplicationMap;
+
+    // Dedup window: processes with same (path + cmdLine + userSid) within this
+    // interval are considered duplicates. Default 1 hour (configurable).
+    static constexpr ULONGLONG DEDUP_WINDOW_MS = 3600000ULL;
+
+    // ETW session handles
+    TRACEHANDLE m_sessionHandle = 0;
+    TRACEHANDLE m_consumerHandle = INVALID_PROCESSTRACE_HANDLE;
+
+    // Thread handles
+    HANDLE m_etwConsumerThread = nullptr;
+    HANDLE m_sysmonPollThread = nullptr;
+
+    // Stop signal
+    HANDLE m_stopEvent = nullptr;
+
+    // Diagnostics (atomic where possible, mutex-protected otherwise)
+    mutable std::mutex m_diagMutex;
+    ProcessTrackerDiagnostics m_diagnostics = {};
+
+    std::atomic<bool> m_isRunning{ false };
+
+    // Cached services.exe PID with TTL-based expiry.
+    // services.exe PID is stable under normal operation, but we refresh
+    // periodically (every 5 minutes) for correctness in edge cases.
+    mutable DWORD m_servicesPid = 0;
+    mutable bool m_servicesPidCached = false;
+    mutable ULONGLONG m_servicesPidCacheExpiry = 0;
+
+    // ETW session name (must be unique system-wide)
+    static constexpr const wchar_t* ETW_SESSION_NAME = L"PanoptesSpectraProcessTracker";
+
+    // Microsoft-Windows-Kernel-Process provider GUID
+    // {22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716}
+    static const GUID s_kernelProcessProviderGuid;
+
+    // Global instance pointer for static ETW callback routing
+    static ProcessTracker* s_instance;
+};
+
+// Snapshot-based collection: enumerate currently running processes.
+// Used as a one-time collection during GenerateJSON() to capture processes
+// that were already running before the ETW session started.
+// Excludes Windows service processes.
+std::vector<RunningProcessInfo> SnapshotRunningProcesses(
+    const std::vector<DWORD>& serviceProcessIds);

--- a/WindowsEnum/src/Service/ServiceConfig.cpp
+++ b/WindowsEnum/src/Service/ServiceConfig.cpp
@@ -95,4 +95,10 @@ namespace ServiceConfig
     {
         return ReadRegistryDword(REG_ENABLE_DETAILED_LOGGING, 0) != 0;
     }
+    
+    bool IsProcessTrackingEnabled()
+    {
+        // Default: enabled (1). Set to 0 in registry to disable.
+        return ReadRegistryDword(REG_ENABLE_PROCESS_TRACKING, 1) != 0;
+    }
 }

--- a/WindowsEnum/src/Service/ServiceConfig.h
+++ b/WindowsEnum/src/Service/ServiceConfig.h
@@ -29,6 +29,7 @@ namespace ServiceConfig
     constexpr const wchar_t* REG_SERVER_URL = L"ServerUrl";
     constexpr const wchar_t* REG_ENABLE_DETAILED_LOGGING = L"EnableDetailedLogging";
     constexpr const wchar_t* REG_OUTPUT_DIRECTORY = L"OutputDirectory";
+    constexpr const wchar_t* REG_ENABLE_PROCESS_TRACKING = L"EnableProcessTracking";
     
     // Default values (used if registry not configured)
     constexpr DWORD DEFAULT_COLLECTION_INTERVAL_SECONDS = 86400; // 24 hours (daily collection)
@@ -56,4 +57,5 @@ namespace ServiceConfig
     std::wstring GetOutputDirectory();
     std::wstring GetServerUrl();
     bool IsDetailedLoggingEnabled();
+    bool IsProcessTrackingEnabled();
 }

--- a/WindowsEnum/src/Service/ServiceMain.cpp
+++ b/WindowsEnum/src/Service/ServiceMain.cpp
@@ -59,6 +59,12 @@ SERVICE_STATUS_HANDLE ServiceMain::g_hServiceStatusHandle = nullptr;
 SERVICE_STATUS ServiceMain::g_serviceStatus = {};
 HANDLE ServiceMain::g_hStopEvent = nullptr;
 HANDLE ServiceMain::g_hWorkerThread = nullptr;
+ProcessTracker ServiceMain::g_processTracker;
+
+ProcessTracker* ServiceMain::GetProcessTracker()
+{
+    return &g_processTracker;
+}
 
 // Run the service (called from main)
 bool ServiceMain::RunService()
@@ -146,7 +152,7 @@ DWORD WINAPI ServiceMain::ServiceControlHandler(DWORD dwControl, DWORD dwEventTy
     {
     case SERVICE_CONTROL_STOP:
         LogError("[!] Service STOP command received");
-        ReportServiceStatus(SERVICE_STOP_PENDING, NO_ERROR, 5000);
+        ReportServiceStatus(SERVICE_STOP_PENDING, NO_ERROR, 30000);
         
         // Signal the worker thread to stop
         if (g_hStopEvent)
@@ -156,7 +162,7 @@ DWORD WINAPI ServiceMain::ServiceControlHandler(DWORD dwControl, DWORD dwEventTy
 
     case SERVICE_CONTROL_SHUTDOWN:
         LogError("[!] System SHUTDOWN detected");
-        ReportServiceStatus(SERVICE_STOP_PENDING, NO_ERROR, 5000);
+        ReportServiceStatus(SERVICE_STOP_PENDING, NO_ERROR, 30000);
         
         // Signal the worker thread to stop
         if (g_hStopEvent)
@@ -222,6 +228,16 @@ DWORD WINAPI ServiceMain::ServiceWorkerThread(LPVOID lpParam)
             LogError("[+] Output directory created successfully");
         }
 
+        // Start real-time process tracking (ETW with Sysmon fallback)
+        if (g_processTracker.Start())
+        {
+            LogError("[+] Real-time process tracking is active");
+        }
+        else
+        {
+            LogError("[!] Real-time process tracking could not be started (disabled or all sources failed)");
+        }
+
         // Perform initial data collection
         LogError("[+] Performing initial data collection...");
         PerformDataCollection();
@@ -257,6 +273,17 @@ DWORD WINAPI ServiceMain::ServiceWorkerThread(LPVOID lpParam)
         }
 
         LogError("[+] Worker thread shutting down");
+
+        // Flush accumulated process data to disk before stopping the tracker.
+        // Without this, all ETW-buffered processes since the last scheduled
+        // collection (up to 24 hours of data) would be lost on service stop
+        // or system reboot. CollectAndReset() inside GenerateProcessJSON()
+        // drains the buffer, so the tracker can be stopped cleanly afterward.
+        LogError("[+] Flushing process data before shutdown...");
+        PerformDataCollection();
+
+        // Stop real-time process tracking
+        g_processTracker.Stop();
 
         // Report that service is stopped
         ReportServiceStatus(SERVICE_STOPPED, NO_ERROR, 0);
@@ -342,25 +369,40 @@ void ServiceMain::PerformDataCollection()
     {
         LogError("[+] Starting inventory data collection");
 
-        // Generate JSON inventory
-        std::string jsonData = GenerateJSON();
-
         // Get output directory from configuration
         std::wstring outputDir = ServiceConfig::GetOutputDirectory();
 
-        // Write to a single inventory file, overwriting previous content.
-        // Only one file is maintained at any given time.
-        std::wstring outputFile = outputDir + L"\\inventory.json";
-        std::ofstream outFile(outputFile, std::ios::out | std::ios::trunc);
+        // Generate and write inventory JSON (apps, updates, services, OS info)
+        std::string jsonData = GenerateJSON();
+
+        std::wstring inventoryFile = outputDir + L"\\inventory.json";
+        std::ofstream outFile(inventoryFile, std::ios::out | std::ios::trunc);
         if (outFile.is_open())
         {
             outFile << jsonData;
             outFile.close();
-            LogError("[+] JSON written to: " + WideToUtf8(outputFile));
+            LogError("[+] Inventory JSON written to: " + WideToUtf8(inventoryFile));
         }
         else
         {
-            LogError("[-] Failed to write JSON file: " + WideToUtf8(outputFile));
+            LogError("[-] Failed to write inventory JSON file: " + WideToUtf8(inventoryFile));
+        }
+
+        // Generate and write process JSON (ETW + snapshot process data)
+        // Overwritten each collection cycle with cumulative ETW data + fresh snapshot.
+        std::string processData = GenerateProcessJSON();
+
+        std::wstring processFile = outputDir + L"\\processes.json";
+        std::ofstream procOutFile(processFile, std::ios::out | std::ios::trunc);
+        if (procOutFile.is_open())
+        {
+            procOutFile << processData;
+            procOutFile.close();
+            LogError("[+] Process JSON written to: " + WideToUtf8(processFile));
+        }
+        else
+        {
+            LogError("[-] Failed to write process JSON file: " + WideToUtf8(processFile));
         }
 
         LogError("[+] Data collection completed successfully");

--- a/WindowsEnum/src/Service/ServiceMain.h
+++ b/WindowsEnum/src/Service/ServiceMain.h
@@ -3,6 +3,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include "../Utils/Utils.h"
+#include "../ProcessTracker.h"
 
 // Windows Service main entry point and control handlers
 class ServiceMain
@@ -17,6 +18,9 @@ public:
     
     // Run the service
     static bool RunService();
+    
+    // Access the process tracker instance (used by GenerateJSON for snapshot data)
+    static ProcessTracker* GetProcessTracker();
 
 private:
     // Service worker thread
@@ -39,4 +43,7 @@ private:
     
     // Worker thread handle
     static HANDLE g_hWorkerThread;
+    
+    // Real-time process tracker (ETW-based with Sysmon fallback)
+    static ProcessTracker g_processTracker;
 };

--- a/WindowsEnum/src/Utils/Utils.cpp
+++ b/WindowsEnum/src/Utils/Utils.cpp
@@ -3,9 +3,11 @@
 #include "../WinAppXPackages.h"
 #include "../Service/MachineId.h"
 #include "../Service/ServiceConfig.h"
+#include "../Service/ServiceMain.h"
 #include <aclapi.h>
 #include <sddl.h>
 #include <unordered_map>
+#include <unordered_set>
 
 // Static mutex for thread-safe logging
 static std::mutex g_logMutex;
@@ -486,6 +488,15 @@ std::string GenerateJSON()
     // Enumerate all installed Windows services via SCM APIs
     std::vector<WindowsServiceInfo> windowsServices = EnumerateWindowsServices();
 
+    // Get process tracker diagnostics summary for inventory metadata.
+    // Full process data is written separately to processes.json.
+    ProcessTrackerDiagnostics trackerDiagnostics = {};
+    ProcessTracker* tracker = ServiceMain::GetProcessTracker();
+    if (tracker != nullptr)
+    {
+        trackerDiagnostics = tracker->GetDiagnostics();
+    }
+
     // Get ISO 8601 timestamp for collection
     auto now = std::chrono::system_clock::now();
     auto time = std::chrono::system_clock::to_time_t(now);
@@ -720,9 +731,156 @@ std::string GenerateJSON()
         if (i + 1 < windowsServices.size()) out << ",";
         out << "\n";
     }
-    out << "  ]\n";
+    out << "  ],\n";
+
+    // Lightweight process tracking summary (full data in processes.json)
+    {
+        auto SourceToString = [](ProcessTrackingSource src) -> const char* {
+            switch (src)
+            {
+            case ProcessTrackingSource::EtwKernelProcess: return "EtwKernelProcess";
+            case ProcessTrackingSource::SysmonEventLog:   return "SysmonEventLog";
+            case ProcessTrackingSource::Disabled:          return "Disabled";
+            default:                                       return "None";
+            }
+        };
+
+        out << "  \"processTrackingSummary\": {\n";
+        out << "    \"activeSource\": \"" << SourceToString(trackerDiagnostics.activeSource) << "\",\n";
+        out << "    \"isActive\": " << (tracker != nullptr && tracker->IsRunning() ? "true" : "false") << ",\n";
+        out << "    \"totalEventsReceived\": " << trackerDiagnostics.totalEventsReceived << ",\n";
+        out << "    \"dataFile\": \"processes.json\"\n";
+        out << "  }\n";
+    }
 
     out << "}\n";
+
+    return out.str();
+}
+
+std::string GenerateProcessJSON()
+{
+    LogError("[+] Collecting running process data for processes.json");
+
+    // Enumerate Windows services to build exclusion list
+    std::vector<WindowsServiceInfo> windowsServices = EnumerateWindowsServices();
+
+    std::vector<DWORD> serviceProcessIds;
+    serviceProcessIds.reserve(windowsServices.size());
+    for (const auto& svc : windowsServices)
+    {
+        if (svc.processId != 0)
+        {
+            serviceProcessIds.push_back(svc.processId);
+        }
+    }
+
+    // Get processes observed by ETW tracker since last collection
+    std::vector<RunningProcessInfo> runningProcesses;
+    ProcessTrackerDiagnostics trackerDiagnostics = {};
+    ProcessTracker* tracker = ServiceMain::GetProcessTracker();
+    if (tracker != nullptr && tracker->IsRunning())
+    {
+        runningProcesses = tracker->CollectAndReset();
+        trackerDiagnostics = tracker->GetDiagnostics();
+    }
+    else if (tracker != nullptr)
+    {
+        trackerDiagnostics = tracker->GetDiagnostics();
+    }
+
+    // Supplement with a point-in-time snapshot of currently running processes.
+    // This catches processes that were already running before the ETW session started.
+    std::vector<RunningProcessInfo> snapshotProcesses = SnapshotRunningProcesses(serviceProcessIds);
+
+    // Merge: add snapshot processes that aren't already in the ETW set (deduplicate by PID)
+    {
+        std::unordered_set<DWORD> etwPids;
+        for (const auto& proc : runningProcesses)
+        {
+            etwPids.insert(proc.processId);
+        }
+        for (auto& proc : snapshotProcesses)
+        {
+            if (etwPids.find(proc.processId) == etwPids.end())
+            {
+                runningProcesses.push_back(std::move(proc));
+            }
+        }
+    }
+
+    // Get ISO 8601 timestamp for this collection
+    auto now = std::chrono::system_clock::now();
+    auto time = std::chrono::system_clock::to_time_t(now);
+    struct tm timeinfo = {};
+    std::string timestamp;
+
+    if (localtime_s(&timeinfo, &time) == 0)
+    {
+        std::ostringstream timestampStream;
+        timestampStream << std::put_time(&timeinfo, "%Y-%m-%dT%H:%M:%S");
+        timestamp = timestampStream.str();
+    }
+    else
+    {
+        timestamp = "UNKNOWN";
+    }
+
+    // JSON Begin — self-describing document with machine ID for correlation
+    std::ostringstream out;
+    out << "{\n";
+    out << "  \"spectraMachineId\": \"" << MachineId::GetMachineIdUtf8() << "\",\n";
+    out << "  \"collectionTimestamp\": \"" << timestamp << "\",\n";
+    out << "  \"agentVersion\": \"" << WideToUtf8(ServiceConfig::VERSION) << "\",\n";
+
+    // Running Processes — non-service processes observed via ETW + snapshot
+    out << "  \"runningProcesses\": [\n";
+    for (size_t i = 0; i < runningProcesses.size(); ++i)
+    {
+        const auto& proc = runningProcesses[i];
+        out << "    {\n";
+        out << "      \"imagePath\": " << JsonEscape(proc.imagePath) << ",\n";
+        out << "      \"commandLine\": " << JsonEscape(proc.commandLine) << ",\n";
+        out << "      \"userSid\": " << JsonEscape(proc.userSid) << ",\n";
+        out << "      \"username\": " << JsonEscape(proc.username) << ",\n";
+        out << "      \"processId\": " << proc.processId << ",\n";
+        out << "      \"parentProcessId\": " << proc.parentProcessId << ",\n";
+        out << "      \"parentImagePath\": " << JsonEscape(proc.parentImagePath) << ",\n";
+        out << "      \"firstSeenTimestamp\": " << JsonEscape(proc.firstSeenTimestamp) << "\n";
+        out << "    }";
+        if (i + 1 < runningProcesses.size()) out << ",";
+        out << "\n";
+    }
+    out << "  ],\n";
+
+    // Process Tracker Diagnostics — full telemetry for troubleshooting
+    {
+        auto SourceToString = [](ProcessTrackingSource src) -> const char* {
+            switch (src)
+            {
+            case ProcessTrackingSource::EtwKernelProcess: return "EtwKernelProcess";
+            case ProcessTrackingSource::SysmonEventLog:   return "SysmonEventLog";
+            case ProcessTrackingSource::Disabled:          return "Disabled";
+            default:                                       return "None";
+            }
+        };
+
+        out << "  \"processTrackerDiagnostics\": {\n";
+        out << "    \"activeSource\": \"" << SourceToString(trackerDiagnostics.activeSource) << "\",\n";
+        out << "    \"etwSessionStartResult\": " << trackerDiagnostics.etwSessionStartResult << ",\n";
+        out << "    \"etwConsumerOpenResult\": " << trackerDiagnostics.etwConsumerOpenResult << ",\n";
+        out << "    \"sysmonAvailable\": " << (trackerDiagnostics.sysmonAvailable ? "true" : "false") << ",\n";
+        out << "    \"totalEventsReceived\": " << trackerDiagnostics.totalEventsReceived << ",\n";
+        out << "    \"eventsDeduplicatedOut\": " << trackerDiagnostics.eventsDeduplicatedOut << ",\n";
+        out << "    \"serviceProcessesExcluded\": " << trackerDiagnostics.serviceProcessesExcluded << ",\n";
+        out << "    \"lastErrorMessage\": " << JsonEscape(trackerDiagnostics.lastErrorMessage) << ",\n";
+        out << "    \"processesCollected\": " << runningProcesses.size() << "\n";
+        out << "  }\n";
+    }
+
+    out << "}\n";
+
+    LogError("[+] Process JSON generated: " + std::to_string(runningProcesses.size()) + " processes");
 
     return out.str();
 }

--- a/WindowsEnum/src/Utils/Utils.h
+++ b/WindowsEnum/src/Utils/Utils.h
@@ -44,6 +44,10 @@ std::string GetWindowsErrorMessage(LONG errorCode);
 // Generate JSON inventory of all system information
 std::string GenerateJSON();
 
+// Generate JSON for running processes (separate from inventory to avoid bloat).
+// Contains ETW real-time data + point-in-time snapshot, process tracker diagnostics.
+std::string GenerateProcessJSON();
+
 // Directory Security Validation Functions
 
 // Check if a path is a directory (not a file)

--- a/WindowsEnum/src/WindowsEnum.h
+++ b/WindowsEnum/src/WindowsEnum.h
@@ -13,3 +13,4 @@
 #include "InstalledUpdates.h"
 #include "OsVersionInfo.h"
 #include "WindowsServices.h"
+#include "ProcessTracker.h"


### PR DESCRIPTION
Implement user-mode ETW consumer using Microsoft-Windows-Kernel-Process provider to capture every process start event in real-time. Falls back to Sysmon event log subscription when ETW session creation fails.

Process tracking pipeline:
- ETW session with WINEVENT_KEYWORD_PROCESS (0x10) keyword filter
- TDH-based event parsing with bounds-safe string extraction (wcsnlen_s)
- Deduplication via composite key (imagePath|commandLine|userSid) with TTL
- Service process exclusion (services.exe parent PID check with cache)
- Point-in-time snapshot merge to catch pre-existing processes

Security hardening:
- Attacker-controlled strings (imagePath, commandLine) capped at 8,192 chars
- Process buffer capped at 100K entries to prevent memory exhaustion
- Dedup map bounded to same limit to prevent key-flooding attacks
- ETW UserData/UserDataLength validated before TDH parsing
- All output sanitized through existing JsonEscape() pipeline

Operational improvements:
- Flush accumulated process data to disk on service stop/reboot
- SCM wait hint increased to 30s to accommodate shutdown flush
- Orphaned ETW session cleanup on startup (crash recovery)
- Full diagnostics (active source, event counts, error codes) in JSON output
- Registry-configurable enable/disable via EnableProcessTracking DWORD

Output: processes.json written alongside inventory.json each collection cycle, containing ETW-observed + snapshot-merged process records with image path, command line, user SID, username, parent process info, and timestamps.

Fixes #55