### PR TITLE
feat(process-tracker): extract PE file version for CVE correlation (#59)

### DIFF
--- a/WindowsEnum/src/ProcessTracker.cpp
+++ b/WindowsEnum/src/ProcessTracker.cpp
@@ -6,6 +6,7 @@
 #include <tdh.h>
 #include <psapi.h>
 #include <winevt.h>
+#include <winver.h>
 #include <iomanip>
 #include <chrono>
 #include <sstream>
@@ -13,6 +14,7 @@
 
 #pragma comment(lib, "advapi32.lib")
 #pragma comment(lib, "tdh.lib")
+#pragma comment(lib, "version.lib")
 
 // ============================================================================
 // RAII Handle Wrappers
@@ -619,6 +621,7 @@ void ProcessTracker::HandleProcessStartEvent(PEVENT_RECORD pEventRecord)
     info.parentProcessId = parentProcessId;
     info.parentImagePath = GetProcessImagePath(parentProcessId);
     info.firstSeenTimestamp = GetCurrentTimestamp();
+    info.fileVersion = GetFileVersion(info.imagePath);
     info.isServiceProcess = false;
 
     // Add to observed processes (with buffer cap to prevent unbounded memory growth)
@@ -1060,6 +1063,94 @@ std::wstring ProcessTracker::GetCurrentTimestamp()
     return wss.str();
 }
 
+std::wstring ProcessTracker::GetFileVersion(const std::wstring& filePath)
+{
+    if (filePath.empty())
+    {
+        return {};
+    }
+
+    // Map the PE into user-mode address space as raw data.
+    // LOAD_LIBRARY_AS_IMAGE_RESOURCE: map sections at virtual addresses so
+    //   FindResourceW can walk the resource directory tree correctly.
+    // LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE: prevent concurrent modification
+    //   of the mapping while we read from it.
+    // No DllMain execution, no import resolution, no compatibility shims.
+    LibraryHandle hModule(LoadLibraryExW(
+        filePath.c_str(),
+        nullptr,
+        LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE | LOAD_LIBRARY_AS_IMAGE_RESOURCE));
+
+    if (!hModule)
+    {
+        return {};
+    }
+
+    // Locate the RT_VERSION resource (resource type 16, resource ID 1)
+    const HRSRC hResInfo = FindResourceW(hModule.Get(), MAKEINTRESOURCEW(1), RT_VERSION);
+    if (hResInfo == nullptr)
+    {
+        return {};
+    }
+
+    const DWORD resSize = SizeofResource(hModule.Get(), hResInfo);
+    if (resSize == 0)
+    {
+        return {};
+    }
+
+    const HGLOBAL hResData = LoadResource(hModule.Get(), hResInfo);
+    if (hResData == nullptr)
+    {
+        return {};
+    }
+
+    const void* pRawData = LockResource(hResData);
+    if (pRawData == nullptr)
+    {
+        return {};
+    }
+
+    // Copy into a writable buffer. The mapped resource pages are read-only,
+    // and VerQueryValueW may write alignment fixups into the buffer.
+    std::vector<BYTE> versionData(
+        static_cast<const BYTE*>(pRawData),
+        static_cast<const BYTE*>(pRawData) + resSize);
+
+    // Parse VS_FIXEDFILEINFO from the raw resource data.
+    // VerQueryValueW is a pure in-memory parser -- no version shim applied here.
+    VS_FIXEDFILEINFO* pFixedInfo = nullptr;
+    UINT fixedInfoSize = 0;
+
+    if (!VerQueryValueW(versionData.data(), L"\\",
+                        reinterpret_cast<LPVOID*>(&pFixedInfo), &fixedInfoSize))
+    {
+        return {};
+    }
+
+    if (pFixedInfo == nullptr || fixedInfoSize < sizeof(VS_FIXEDFILEINFO))
+    {
+        return {};
+    }
+
+    // Validate the magic signature (0xFEEF04BD)
+    if (pFixedInfo->dwSignature != VS_FFI_SIGNATURE)
+    {
+        return {};
+    }
+
+    // Extract Major.Minor.Build.Revision from dwFileVersionMS / dwFileVersionLS
+    const DWORD major    = HIWORD(pFixedInfo->dwFileVersionMS);
+    const DWORD minor    = LOWORD(pFixedInfo->dwFileVersionMS);
+    const DWORD build    = HIWORD(pFixedInfo->dwFileVersionLS);
+    const DWORD revision = LOWORD(pFixedInfo->dwFileVersionLS);
+
+    return std::to_wstring(major) + L"." +
+           std::to_wstring(minor) + L"." +
+           std::to_wstring(build) + L"." +
+           std::to_wstring(revision);
+}
+
 // ============================================================================
 // Snapshot-based Collection (point-in-time enumeration)
 // ============================================================================
@@ -1169,6 +1260,7 @@ std::vector<RunningProcessInfo> SnapshotRunningProcesses(
         info.parentProcessId = entry.parentProcessId;
         info.parentImagePath = ProcessTracker::GetProcessImagePath(entry.parentProcessId);
         info.firstSeenTimestamp = ProcessTracker::GetCurrentTimestamp();
+        info.fileVersion = ProcessTracker::GetFileVersion(info.imagePath);
         info.isServiceProcess = false;
 
         processes.push_back(std::move(info));

--- a/WindowsEnum/src/ProcessTracker.h
+++ b/WindowsEnum/src/ProcessTracker.h
@@ -23,6 +23,7 @@ struct RunningProcessInfo
     DWORD parentProcessId = 0;         // PID of the parent process
     std::wstring parentImagePath;       // Image path of the parent process (best-effort)
     std::wstring firstSeenTimestamp;    // ISO 8601 timestamp when first observed
+    std::wstring fileVersion;           // PE file version from RT_VERSION resource (e.g., "114.0.5735.199")
     bool isServiceProcess = false;      // True if process is a known Windows service
 };
 
@@ -139,6 +140,11 @@ public:
 
     // Build ISO 8601 timestamp string
     static std::wstring GetCurrentTimestamp();
+
+    // Extract PE file version (Major.Minor.Build.Revision) from the RT_VERSION resource.
+    // Uses LoadLibraryExW(DATAFILE) to map the PE without executing code or applying
+    // the GetFileVersionInfo compatibility shim. Returns empty string on failure.
+    static std::wstring GetFileVersion(const std::wstring& filePath);
 
 private:
 

--- a/WindowsEnum/src/Utils/Utils.cpp
+++ b/WindowsEnum/src/Utils/Utils.cpp
@@ -846,7 +846,8 @@ std::string GenerateProcessJSON()
         out << "      \"processId\": " << proc.processId << ",\n";
         out << "      \"parentProcessId\": " << proc.parentProcessId << ",\n";
         out << "      \"parentImagePath\": " << JsonEscape(proc.parentImagePath) << ",\n";
-        out << "      \"firstSeenTimestamp\": " << JsonEscape(proc.firstSeenTimestamp) << "\n";
+        out << "      \"firstSeenTimestamp\": " << JsonEscape(proc.firstSeenTimestamp) << ",\n";
+        out << "      \"fileVersion\": " << JsonEscape(proc.fileVersion) << "\n";
         out << "    }";
         if (i + 1 < runningProcesses.size()) out << ",";
         out << "\n";


### PR DESCRIPTION
Add fileVersion field to RunningProcessInfo, populated at ingestion time from the binary's RT_VERSION resource. Enables vulnerability scanners to match observed processes (e.g., ChromeDriver.exe 114.0.5735.199) against known CVEs without requiring a separate file inventory pass.

Implementation:
- Add GetFileVersion() static helper using LoadLibraryExW(DATAFILE) + FindResourceW(RT_VERSION) + VerQueryValueW to extract VS_FIXEDFILEINFO
- Bypass GetFileVersionInfoW compatibility shim (same proven technique as OsVersionInfo::ReadFileVersion for ntoskrnl.exe)
- Wire into ETW callback (HandleProcessStartEvent) at ingestion time when the binary is guaranteed to exist on disk
- Wire into SnapshotRunningProcesses for point-in-time collection path
- Serialize as "fileVersion" in processes.json for each process record
- Graceful degradation: returns empty string for binaries without RT_VERSION resource (scripts, .NET single-file, unsigned tools)

Performance: LoadLibraryExW(DATAFILE_EXCLUSIVE | IMAGE_RESOURCE) creates a read-only file mapping with no DllMain, no import resolution, no shims. Cost is comparable to the existing OpenProcess + token query chain already in the ETW callback hot path.

Files changed:
- src/ProcessTracker.h    - Add fileVersion field + GetFileVersion decl
- src/ProcessTracker.cpp  - Implement GetFileVersion, wire both paths
- src/Utils/Utils.cpp     - Add fileVersion to process JSON serialization

Fixes #59